### PR TITLE
Allow specifying S3 storage class in task

### DIFF
--- a/src/main/java/jp/classmethod/aws/gradle/s3/SyncTask.java
+++ b/src/main/java/jp/classmethod/aws/gradle/s3/SyncTask.java
@@ -21,7 +21,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
-import com.amazonaws.services.s3.model.StorageClass;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -36,6 +35,7 @@ import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.AmazonS3Exception;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.amazonaws.services.s3.model.StorageClass;
 import com.google.common.hash.Hashing;
 import com.google.common.io.Files;
 
@@ -72,7 +72,7 @@ public class SyncTask extends ConventionTask {
 	@Getter
 	@Setter
 	private int threads = 5;
-
+	
 	@Getter
 	@Setter
 	private StorageClass storageClass = StorageClass.Standard;
@@ -120,7 +120,8 @@ public class SyncTask extends ConventionTask {
 			
 			
 			public void visitFile(FileVisitDetails element) {
-				es.execute(new UploadTask(s3, element, bucketName, prefix, storageClass, metadataProvider, getLogger()));
+				es.execute(
+						new UploadTask(s3, element, bucketName, prefix, storageClass, metadataProvider, getLogger()));
 			}
 		});
 		
@@ -151,19 +152,20 @@ public class SyncTask extends ConventionTask {
 	
 	
 	private static class UploadTask implements Runnable {
-
-
+		
+		
 		private AmazonS3 s3;
+		
 		private FileVisitDetails element;
-
+		
 		private String bucketName;
-
+		
 		private String prefix;
-
+		
 		private Closure<ObjectMetadata> metadataProvider;
-
+		
 		private StorageClass storageClass;
-
+		
 		private Logger logger;
 		
 		


### PR DESCRIPTION
This adds in the ability to specify a storage class for objects that are being synced to S3.