### PR TITLE
Update plugin version in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ buildscript {
     maven { url "https://plugins.gradle.org/m2/" }
   }
   dependencies {
-    classpath "jp.classmethod.aws:gradle-aws-plugin:0.21"
+    classpath "jp.classmethod.aws:gradle-aws-plugin:0.30"
   }
 }
 


### PR DESCRIPTION
Using the old version can cause problems, e.g. https://github.com/classmethod/gradle-aws-plugin/issues/73.