### PR TITLE
Make CFN wait fail on rollback

### DIFF
--- a/src/main/java/jp/classmethod/aws/gradle/cloudformation/AmazonCloudFormationWaitStackStatusTask.java
+++ b/src/main/java/jp/classmethod/aws/gradle/cloudformation/AmazonCloudFormationWaitStackStatusTask.java
@@ -42,8 +42,6 @@ public class AmazonCloudFormationWaitStackStatusTask extends ConventionTask {
 	private List<String> successStatuses = Arrays.asList(
 			"CREATE_COMPLETE",
 			"UPDATE_COMPLETE",
-			"ROLLBACK_COMPLETE",
-			"UPDATE_ROLLBACK_COMPLETE",
 			"DELETE_COMPLETE");
 	
 	@Getter


### PR DESCRIPTION
We think the `AmazonCloudFormationWaitStackStatusTask` shall fail on rollback. If I'm doing a stack update and it fails, then the stack ends up in a "rollback complete" status. An update or creation failure is the only reason to be in this status. We think the task should throw in this case.