### PR TITLE
Add support for CAPABILITY_NAMED_IAM

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -14,6 +14,7 @@ To do this cd to the project where you would like to use your own checkout of th
 
 ```bash
 mkdir buildSrc
+cd buildSrc
 ln -s /path/to/gradle-aws-plugin ./
 ```
 
@@ -24,6 +25,7 @@ _`buildSrc/build.gradle`_
 apply plugin: "java"
 
 repositories {
+  jcenter()
   mavenCentral()
 }
 

--- a/src/main/java/jp/classmethod/aws/gradle/cloudformation/AmazonCloudFormationMigrateStackTask.java
+++ b/src/main/java/jp/classmethod/aws/gradle/cloudformation/AmazonCloudFormationMigrateStackTask.java
@@ -65,6 +65,10 @@ public class AmazonCloudFormationMigrateStackTask extends ConventionTask {
 	
 	@Getter
 	@Setter
+	private Capability useCapabilityIam;
+	
+	@Getter
+	@Setter
 	private String cfnStackPolicyUrl;
 	
 	@Getter
@@ -136,7 +140,10 @@ public class AmazonCloudFormationMigrateStackTask extends ConventionTask {
 			.withParameters(cfnStackParams)
 			.withTags(cfnStackTags);
 		if (isCapabilityIam()) {
-			req.setCapabilities(Arrays.asList(Capability.CAPABILITY_IAM.toString()));
+			Capability selectedCapability =
+					(useCapabilityIam == null) ? Capability.CAPABILITY_IAM : useCapabilityIam;
+			getLogger().error("Using policy: " + selectedCapability);
+			req.setCapabilities(Arrays.asList(selectedCapability.toString()));
 		}
 		if (Strings.isNullOrEmpty(cfnStackPolicyUrl) == false) {
 			req.setStackPolicyURL(cfnStackPolicyUrl);
@@ -171,7 +178,10 @@ public class AmazonCloudFormationMigrateStackTask extends ConventionTask {
 			.withParameters(cfnStackParams)
 			.withTags(cfnStackTags);
 		if (isCapabilityIam()) {
-			req.setCapabilities(Arrays.asList(Capability.CAPABILITY_IAM.toString()));
+			Capability selectedCapability =
+					(useCapabilityIam == null) ? Capability.CAPABILITY_IAM : useCapabilityIam;
+			getLogger().error("Using policy: " + selectedCapability);
+			req.setCapabilities(Arrays.asList(selectedCapability.toString()));
 		}
 		if (Strings.isNullOrEmpty(cfnStackPolicyUrl) == false) {
 			req.setStackPolicyURL(cfnStackPolicyUrl);

--- a/src/main/java/jp/classmethod/aws/gradle/cloudformation/AmazonCloudFormationPlugin.java
+++ b/src/main/java/jp/classmethod/aws/gradle/cloudformation/AmazonCloudFormationPlugin.java
@@ -84,6 +84,7 @@ public class AmazonCloudFormationPlugin implements Plugin<Project> {
 				task.mustRunAfter(awsCfnUploadPolicy);
 				task.conventionMapping("stackName", () -> cfnExt.getStackName());
 				task.conventionMapping("capabilityIam", () -> cfnExt.isCapabilityIam());
+				task.conventionMapping("useCapabilityIam", () -> cfnExt.getUseCapabilityIam());
 				task.conventionMapping("cfnStackParams", () -> cfnExt.getStackParams().entrySet().stream()
 					.map(it -> new Parameter()
 						.withParameterKey(it.getKey().toString())

--- a/src/main/java/jp/classmethod/aws/gradle/cloudformation/AmazonCloudFormationPluginExtension.java
+++ b/src/main/java/jp/classmethod/aws/gradle/cloudformation/AmazonCloudFormationPluginExtension.java
@@ -33,6 +33,7 @@ import org.gradle.api.Project;
 
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.services.cloudformation.AmazonCloudFormationClient;
+import com.amazonaws.services.cloudformation.model.Capability;
 import com.amazonaws.services.cloudformation.model.DescribeStackResourcesRequest;
 import com.amazonaws.services.cloudformation.model.DescribeStackResourcesResult;
 import com.amazonaws.services.cloudformation.model.DescribeStacksRequest;
@@ -96,6 +97,10 @@ public class AmazonCloudFormationPluginExtension extends BaseRegionAwarePluginEx
 	@Getter
 	@Setter
 	private boolean capabilityIam;
+	
+	@Getter
+	@Setter
+	private Capability useCapabilityIam;
 	
 	
 	public AmazonCloudFormationPluginExtension(Project project) {


### PR DESCRIPTION
I'm looking to support CAPABILITY_NAMED_IAM however I've been having difficulty testing it out. I've added it to the buildSrc of our project and tried it out on our stack, however, based on the logging, I'm pretty sure that the requested value of useCapabilityIam does not get passed through to AmazonCloudFormationMigrateStackTask. In fact, the lambda I added to the creation function via the convention mapping I don't think is being called.

Modeling the change after how the capabilityIam property is defined but I can't see what is different about what I'm doing. Any assistance either determining the issue or how to track down the problem would be appreciated. Thank you much!