### PR TITLE
Enhancements to cloudformation and AWSLambdaInvokeTask

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -76,7 +76,7 @@ jacocoTestReport {
 // checkstyle
 checkstyle {
 	toolVersion = "7.1.2"
-	configFile = rootProject.file('config/checkstyle/checkstyle.xml')
+	configFile = project.file('config/checkstyle/checkstyle.xml')
 }
 checkstyleTest {
 	configFile = file("config/checkstyle/checkstyle-test.xml")
@@ -164,20 +164,20 @@ spotless {
 		licenseHeaderFile 'config/spotless/spotless.license.java'
 		importOrderFile   'config/spotless/spotless.importorder'
 		eclipseFormatFile 'config/spotless/spotless.eclipseformat.xml'
-		
+
 		// Eclipse formatter screws up long literals with underscores inside of annotations (see issue #14)
 		//    @Max(value = 9_999_999 L) // what Eclipse does
 		//    @Max(value = 9_999_999L)  // what I wish Eclipse did
 		custom 'Long literal fix', { it.replaceAll('([0-9_]+) [Ll]', '$1L') }
-		
+
 		// Eclipse formatter puts excess whitespace after lambda blocks
 		//    funcThatTakesLambdas(x -> {} , y -> {} )	// what Eclipse does
 		//    funcThatTakesLambdas(x -> {}, y -> {})	// what I wish Eclipse did
 		custom 'Lambda fix', { it.replace('} )', '})').replace('} ,', '},') }
-		
+
 		indentWithTabs()
 		endWithNewline()
-		
+
 		customReplaceRegex 'Add space before comment asterisk', '^(\\t*)\\*', '$1 *'
 //		customReplaceRegex 'Remove indent before line comment', '^\\t*//', '//'
 	}
@@ -230,7 +230,7 @@ dependencies {
 	compile "com.google.guava:guava:$guavaVersion"
 	compile "commons-io:commons-io:1.4"
 	compile "org.projectlombok:lombok:$lombokVersion"
-	
+
 	compile "com.amazonaws:aws-java-sdk-sts:$awsJavaSdkVersion"
 	compile "com.amazonaws:aws-java-sdk-s3:$awsJavaSdkVersion"
 	compile "com.amazonaws:aws-java-sdk-ec2:$awsJavaSdkVersion"
@@ -243,9 +243,9 @@ dependencies {
 	compile "com.amazonaws:aws-java-sdk-iam:$awsJavaSdkVersion"
 	compile "com.amazonaws:aws-java-sdk-sqs:$awsJavaSdkVersion"
 	compile "com.amazonaws:aws-java-sdk-sns:$awsJavaSdkVersion"
-	
+
 	compile "jp.xet.spar-wings:spar-wings-awscli-config:$sparWingsVersion"
-	
+
 	// tests
 	testCompile "junit:junit:$junitVersion"
 	testCompile "org.hamcrest:hamcrest-library:$hamcrestVersion"

--- a/samples/06A-cloudformation/build.gradle
+++ b/samples/06A-cloudformation/build.gradle
@@ -1,0 +1,63 @@
+apply plugin: 'groovy'
+apply plugin: 'jp.classmethod.aws.cloudformation'
+
+apply from: 'deploy-dev.groovy'
+
+import jp.classmethod.aws.gradle.s3.SyncTask
+import jp.classmethod.aws.gradle.cloudformation.AmazonCloudFormationPluginExtension
+
+group 'example'
+version = "SNAPSHOT-${project.rootProject.startTime.format('yyMMddHHmm')}"
+
+repositories {
+  mavenCentral()
+}
+
+dependencies {
+  compile 'org.codehaus.groovy:groovy-all:2.4.4'
+  compile 'com.amazonaws:aws-lambda-java-core:1.0.0'
+}
+
+task buildZip(type: Zip) {
+  from compileGroovy
+  from processResources
+  into('lib') {
+    from configurations.runtime
+  }
+}
+
+build.dependsOn buildZip
+
+task uploadLamdbdaToS3(type: SyncTask) {
+  dependsOn build
+
+  delete true
+  bucketName "${cloudFormation.stackParams['pArtifactBucket']}"
+  prefix "${cloudFormation.stackParams['pArtifactPrefix']}/"
+  source file("$buildDir/distributions")
+}
+
+task updateStack (dependsOn: [uploadLamdbdaToS3, awsCfnMigrateStackAndWaitCompleted]) {
+  group 'CNN'
+  description "Creates/Updates $cloudFormation.stackName stack"
+}
+
+task deleteStack (dependsOn: awsCfnDeleteStackAndWaitCompleted) {
+  group 'CNN'
+  description "Deletes $cloudFormation.stackName stack"
+}
+
+awsCfnMigrateStack.mustRunAfter uploadLamdbdaToS3
+awsCfnWaitStackComplete.loopTimeout = 10800 // = 3hr
+awsCfnWaitStackDeleted.loopTimeout = 10800 // = 3hr
+
+task getStackInfo {
+  doLast {
+    def stackName = cloudFormation.getStackOutputValue('StackName')
+    def lambdaArn = cloudFormation.getStackOutputValue('LambdaArn')
+
+    println """
+$stackName
+$lambdaArn"""
+  }
+}

--- a/samples/06A-cloudformation/cloudformation/HelloWorld.yml
+++ b/samples/06A-cloudformation/cloudformation/HelloWorld.yml
@@ -1,0 +1,43 @@
+---
+AWSTemplateFormatVersion: '2010-09-09'
+Description: A groovy lambda
+Parameters:
+  pArtifactBucket:
+    Description: The name of the S3 bucket that contains the source code of your Lambda
+      function.
+    Type: String
+  pArtifactPrefix:
+    Description: Prefix of the objects for the  Lambdas
+    Type: String
+  pHelloWorldZipFile:
+    Description: The location and name of your source code .zip file.
+    Type: String
+Resources:
+  HelloWorld:
+    Type: AWS::Lambda::Function
+    Properties:
+      Code:
+        S3Bucket:
+          Ref: pArtifactBucket
+        S3Key:
+          Fn::Join:
+          - "/"
+          - - Ref: pArtifactPrefix
+            - Ref: pHelloWorldZipFile
+      Handler: example.Hello::myHandler
+      Runtime: java8
+      Description: A groovy lambda
+      MemorySize: 512
+      Timeout: 15
+      Role: arn:aws:iam::496486987401:role/lambda_basic_execution
+Outputs:
+  StackName:
+    Description: StackName
+    Value:
+      Ref: AWS::StackName
+  LambdaArn:
+    Description: Lambda ARN
+    Value:
+      Fn::GetAtt:
+      - HelloWorld
+      - Arn

--- a/samples/06A-cloudformation/cloudformation/stackpolicy.json
+++ b/samples/06A-cloudformation/cloudformation/stackpolicy.json
@@ -1,0 +1,14 @@
+{
+  "Statement" : [
+    {
+      "Resource": "*",
+      "Effect": "Allow",
+      "Principal": "*",
+      "Action": [
+        "Update:Modify",
+        "Update:Delete",
+        "Update:Replace"
+      ]
+    }
+  ]
+}

--- a/samples/06A-cloudformation/deploy-dev.groovy
+++ b/samples/06A-cloudformation/deploy-dev.groovy
@@ -1,0 +1,19 @@
+aws {
+  profileName = "default"
+  region = "ap-northeast-1"
+}
+
+cloudFormation {
+  stackName "HelloWorld-stack"
+  capabilityIam true
+  templateFile project.file('cloudformation/HelloWorld.yml')
+  stackPolicyFile project.file('cloudformation/stackpolicy.json')
+  onFailure 'DO_NOTHING'
+
+  stackParams ([
+    'pArtifactBucket': 'my-deploy-dev',
+    'pArtifactPrefix': 'helloworld-example',
+
+    'pHelloWorldZipFile' : "06A-cloudformation-${-> version}.zip"
+  ])
+}

--- a/samples/06A-cloudformation/src/main/groovy/example/Hello.groovy
+++ b/samples/06A-cloudformation/src/main/groovy/example/Hello.groovy
@@ -1,0 +1,15 @@
+//
+// Borrowed from https://medium.com/@benorama/how-to-build-a-microservice-with-aws-lambda-in-groovy-4f7384c3b804#.9z2rs5hud
+//
+
+package example
+
+import com.amazonaws.services.lambda.runtime.Context
+
+class Hello {
+  Map myHandler(data, Context context) {
+    context.logger.log "received in groovy: $data"
+    [greeting: "Hello, ${data?.firstName} ${data?.lastName}".toString()]
+  }
+
+}

--- a/src/main/java/jp/classmethod/aws/gradle/cloudformation/AmazonCloudFormationMigrateStackTask.java
+++ b/src/main/java/jp/classmethod/aws/gradle/cloudformation/AmazonCloudFormationMigrateStackTask.java
@@ -15,6 +15,8 @@
  */
 package jp.classmethod.aws.gradle.cloudformation;
 
+import java.io.File;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -22,6 +24,7 @@ import java.util.List;
 import lombok.Getter;
 import lombok.Setter;
 
+import org.apache.commons.io.FileUtils;
 import org.gradle.api.GradleException;
 import org.gradle.api.internal.ConventionTask;
 import org.gradle.api.tasks.TaskAction;
@@ -53,6 +56,10 @@ public class AmazonCloudFormationMigrateStackTask extends ConventionTask {
 	
 	@Getter
 	@Setter
+	private File cfnTemplateFile;
+	
+	@Getter
+	@Setter
 	private List<Parameter> cfnStackParams = new ArrayList<>();
 	
 	@Getter
@@ -69,6 +76,14 @@ public class AmazonCloudFormationMigrateStackTask extends ConventionTask {
 	
 	@Getter
 	@Setter
+	private File cfnStackPolicyFile;
+	
+	@Getter
+	@Setter
+	private String cfnOnFailure;
+	
+	@Getter
+	@Setter
 	private List<String> stableStatuses = Arrays.asList(
 			"CREATE_COMPLETE", "ROLLBACK_COMPLETE", "UPDATE_COMPLETE", "UPDATE_ROLLBACK_COMPLETE");
 	
@@ -79,17 +94,13 @@ public class AmazonCloudFormationMigrateStackTask extends ConventionTask {
 	}
 	
 	@TaskAction
-	public void createOrUpdateStack() throws InterruptedException {
+	public void createOrUpdateStack() throws InterruptedException, IOException {
 		// to enable conventionMappings feature
 		String stackName = getStackName();
-		String cfnTemplateUrl = getCfnTemplateUrl();
 		List<String> stableStatuses = getStableStatuses();
 		
 		if (stackName == null) {
 			throw new GradleException("stackName is not specified");
-		}
-		if (cfnTemplateUrl == null) {
-			throw new GradleException("cfnTemplateUrl is not specified");
 		}
 		
 		AmazonCloudFormationPluginExtension ext =
@@ -121,26 +132,43 @@ public class AmazonCloudFormationMigrateStackTask extends ConventionTask {
 		}
 	}
 	
-	private void updateStack(AmazonCloudFormation cfn) {
+	private void updateStack(AmazonCloudFormation cfn) throws IOException {
 		// to enable conventionMappings feature
 		String stackName = getStackName();
 		String cfnTemplateUrl = getCfnTemplateUrl();
 		List<Parameter> cfnStackParams = getCfnStackParams();
 		List<Tag> cfnStackTags = getCfnStackTags();
 		String cfnStackPolicyUrl = getCfnStackPolicyUrl();
+		File cfnTemplateFile = getCfnTemplateFile();
+		File cfnStackPolicyFile = getCfnStackPolicyFile();
 		
 		getLogger().info("Update stack: {}", stackName);
 		UpdateStackRequest req = new UpdateStackRequest()
 			.withStackName(stackName)
-			.withTemplateURL(cfnTemplateUrl)
 			.withParameters(cfnStackParams)
 			.withTags(cfnStackTags);
+		
+		// If template URL is specified, then use it
+		if (Strings.isNullOrEmpty(cfnTemplateUrl) == false) {
+			req.setTemplateURL(cfnTemplateUrl);
+			getLogger().info("Using template url: {}", cfnTemplateUrl);
+			// Else, use the template file body
+		} else {
+			req.setTemplateBody(FileUtils.readFileToString(cfnTemplateFile));
+			getLogger().info("Using template file: {}", "$cfnTemplateFile.canonicalPath");
+		}
 		if (isCapabilityIam()) {
 			req.setCapabilities(Arrays.asList(Capability.CAPABILITY_IAM.toString()));
 		}
+		
+		// If stack policy is specified, then use it
 		if (Strings.isNullOrEmpty(cfnStackPolicyUrl) == false) {
 			req.setStackPolicyURL(cfnStackPolicyUrl);
+			// Else, use the stack policy file body
+		} else {
+			req.setStackPolicyBody(FileUtils.readFileToString(cfnStackPolicyFile));
 		}
+		
 		UpdateStackResult updateStackResult = cfn.updateStack(req);
 		getLogger().info("Update requested: {}", updateStackResult.getStackId());
 	}
@@ -155,27 +183,45 @@ public class AmazonCloudFormationMigrateStackTask extends ConventionTask {
 		Thread.sleep(3000);
 	}
 	
-	private void createStack(AmazonCloudFormation cfn) {
+	private void createStack(AmazonCloudFormation cfn) throws IOException {
 		// to enable conventionMappings feature
 		String stackName = getStackName();
 		String cfnTemplateUrl = getCfnTemplateUrl();
 		List<Parameter> cfnStackParams = getCfnStackParams();
 		List<Tag> cfnStackTags = getCfnStackTags();
 		String cfnStackPolicyUrl = getCfnStackPolicyUrl();
+		File cfnTemplateFile = getCfnTemplateFile();
+		File cfnStackPolicyFile = getCfnStackPolicyFile();
+		String cfnOnFailure = getCfnOnFailure();
 		
 		getLogger().info("create stack: {}", stackName);
 		
 		CreateStackRequest req = new CreateStackRequest()
 			.withStackName(stackName)
-			.withTemplateURL(cfnTemplateUrl)
 			.withParameters(cfnStackParams)
-			.withTags(cfnStackTags);
+			.withTags(cfnStackTags)
+			.withOnFailure(cfnOnFailure);
+		
+		// If template URL is specified, then use it
+		if (Strings.isNullOrEmpty(cfnTemplateUrl) == false) {
+			req.setTemplateURL(cfnTemplateUrl);
+			// Else, use the template file body
+		} else {
+			req.setTemplateBody(FileUtils.readFileToString(cfnTemplateFile));
+		}
 		if (isCapabilityIam()) {
 			req.setCapabilities(Arrays.asList(Capability.CAPABILITY_IAM.toString()));
 		}
+		
+		// If stack policy is specified, then use it
 		if (Strings.isNullOrEmpty(cfnStackPolicyUrl) == false) {
+			
 			req.setStackPolicyURL(cfnStackPolicyUrl);
+			// Else, use the stack policy file body
+		} else {
+			req.setStackPolicyBody(FileUtils.readFileToString(cfnStackPolicyFile));
 		}
+		
 		CreateStackResult createStackResult = cfn.createStack(req);
 		getLogger().info("create requested: {}", createStackResult.getStackId());
 	}

--- a/src/main/java/jp/classmethod/aws/gradle/cloudformation/AmazonCloudFormationPlugin.java
+++ b/src/main/java/jp/classmethod/aws/gradle/cloudformation/AmazonCloudFormationPlugin.java
@@ -89,14 +89,25 @@ public class AmazonCloudFormationPlugin implements Plugin<Project> {
 						.withParameterKey(it.getKey().toString())
 						.withParameterValue(it.getValue().toString()))
 					.collect(Collectors.toList()));
-				task.conventionMapping("cfnTemplateUrl", () -> cfnExt.getTemplateURL());
-				task.conventionMapping("cfnStackPolicyUrl", () -> cfnExt.getStackPolicyURL());
 				task.conventionMapping("cfnStackTags", () -> cfnExt.getStackTags().entrySet().stream()
 					.map(it -> new Tag()
 						.withKey(it.getKey().toString())
 						.withValue(it.getValue().toString()))
 					.collect(Collectors.toList()));
+				task.conventionMapping("cfnTemplateUrl", () -> cfnExt.getTemplateURL());
+				task.conventionMapping("cfnTemplateFile", () -> cfnExt.getTemplateFile());
+				task.conventionMapping("cfnStackPolicyUrl", () -> cfnExt.getStackPolicyURL());
+				task.conventionMapping("cfnStackPolicyFile", () -> cfnExt.getStackPolicyFile());
+				task.conventionMapping("cfnOnFailure", () -> cfnExt.getOnFailure());
 			});
+		
+		project.getTasks()
+			.create("awsCfnValidateTemplateUrl", AmazonCloudFormationValidateTemplateUrlTask.class,
+					task -> {
+						task.setDescription("Validate template URL.");
+						task.conventionMapping("cfnTemplateUrl", () -> cfnExt.getTemplateURL());
+						task.dependsOn(awsCfnUploadTemplate);
+					});
 		
 		project.getTasks()
 			.create("awsCfnCreateChangeSet", AmazonCloudFormationCreateChangeSetTask.class, task -> {
@@ -109,12 +120,13 @@ public class AmazonCloudFormationPlugin implements Plugin<Project> {
 						.withParameterKey(it.getKey().toString())
 						.withParameterValue(it.getValue().toString()))
 					.collect(Collectors.toList()));
-				task.conventionMapping("cfnTemplateUrl", () -> cfnExt.getTemplateURL());
 				task.conventionMapping("cfnStackTags", () -> cfnExt.getStackTags().entrySet().stream()
 					.map(it -> new Tag()
 						.withKey(it.getKey().toString())
 						.withValue(it.getValue().toString()))
 					.collect(Collectors.toList()));
+				task.conventionMapping("cfnTemplateUrl", () -> cfnExt.getTemplateURL());
+				task.conventionMapping("cfnTemplateFile", () -> cfnExt.getTemplateFile());
 			});
 		
 		project.getTasks().create("awsCfnWaitStackReady", AmazonCloudFormationWaitStackStatusTask.class, task -> {

--- a/src/main/java/jp/classmethod/aws/gradle/cloudformation/AmazonCloudFormationValidateTemplateUrlTask.java
+++ b/src/main/java/jp/classmethod/aws/gradle/cloudformation/AmazonCloudFormationValidateTemplateUrlTask.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2015-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package jp.classmethod.aws.gradle.cloudformation;
+
+import java.io.IOException;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import org.gradle.api.GradleException;
+import org.gradle.api.internal.ConventionTask;
+import org.gradle.api.tasks.TaskAction;
+
+public class AmazonCloudFormationValidateTemplateUrlTask extends ConventionTask {
+	
+	@Getter
+	@Setter
+	private String cfnTemplateUrl;
+	
+	
+	public AmazonCloudFormationValidateTemplateUrlTask() {
+		setDescription("Validate template URL.");
+		setGroup("AWS");
+	}
+	
+	@TaskAction
+	public void validateTemplateUrl() throws InterruptedException, IOException {
+		// to enable conventionMappings feature
+		String cfnTemplateUrl = getCfnTemplateUrl();
+		AmazonCloudFormationPluginExtension ext =
+				getProject().getExtensions().getByType(AmazonCloudFormationPluginExtension.class);
+		
+		if (!ext.isValidTemplateUrl(cfnTemplateUrl)) {
+			throw new GradleException("cloudFormation template has invalid format");
+		}
+	}
+}

--- a/src/main/java/jp/classmethod/aws/gradle/lambda/AWSLambdaInvokeTask.java
+++ b/src/main/java/jp/classmethod/aws/gradle/lambda/AWSLambdaInvokeTask.java
@@ -73,7 +73,7 @@ public class AWSLambdaInvokeTask extends ConventionTask {
 	}
 	
 	@TaskAction
-	public void deleteFunction() throws FileNotFoundException, IOException {
+	public void invokeFunction() throws FileNotFoundException, IOException {
 		// to enable conventionMappings feature
 		String functionName = getFunctionName();
 		
@@ -105,12 +105,14 @@ public class AWSLambdaInvokeTask extends ConventionTask {
 		if (payload instanceof File) {
 			File file = (File) payload;
 			str = Files.toString(file, Charsets.UTF_8);
+			request.setPayload(str);
 		} else if (payload instanceof Closure) {
 			Closure<?> closure = (Closure<?>) payload;
 			str = closure.call().toString();
-		} else {
+			request.setPayload(str);
+		} else if (payload instanceof String) {
 			str = payload.toString();
+			request.setPayload(str);
 		}
-		request.setPayload(str);
 	}
 }

--- a/src/main/java/jp/classmethod/aws/gradle/s3/SyncTask.java
+++ b/src/main/java/jp/classmethod/aws/gradle/s3/SyncTask.java
@@ -126,7 +126,7 @@ public class SyncTask extends ConventionTask {
 		
 		ExecutorService es = Executors.newFixedThreadPool(threads);
 		getLogger().info("Start uploading");
-		getLogger().info("uploading... {} to s3://{}/{}", bucketName, bucketName, prefix);
+		getLogger().info("Uploading... {} to s3://{}/{}", source, bucketName, prefix);
 		getProject().fileTree(source).visit(new EmptyFileVisitor() {
 			
 			public void visitFile(FileVisitDetails element) {


### PR DESCRIPTION
**cloudformation**
  AmazonCloudFormationCreateChangeSetTask.java:
    added cfnTemplateFile

  AmazonCloudFormationMigrateStackTask.java:
    added cfnTemplateFile
    added cfnStackPolicyFile
    added cfnOnFailure

  AmazonCloudFormationPlugin.java:
    added needed conventionMappings for awsCfnMigrateStack and awsCfnCreateChangeSet
      
  AmazonCloudFormationPluginExtension.java:
    added onFailure
    added getStackOutputs()
    added getStackOutputs(String stackName)
    added getStackOutputValue(String key)
    added getStackOutputValue(String stackName, String key)
    added findStackOutputValue(List<Output> cfnStackOutputs, String key)
    added isValidTemplateBody(String templateBody)
    added isValidTemplateUrl(String templateUrl)

  AmazonCloudFormationValidateTemplateUrlTask.java:
    added AmazonCloudFormationValidateTemplateUrlTask
    
**lambda**
  AWSLambdaInvokeTask.java:
    added support for null payload

**s3**
  SyncTask.java:
    corrected log message

**build.gradle**
  Changed configFile so that it would work within buildSrc
  