### PR TITLE
#85: Remove try/catch in `getStack`

### DIFF
--- a/src/main/java/jp/classmethod/aws/gradle/cloudformation/AmazonCloudFormationPluginExtension.java
+++ b/src/main/java/jp/classmethod/aws/gradle/cloudformation/AmazonCloudFormationPluginExtension.java
@@ -119,15 +119,11 @@ public class AmazonCloudFormationPluginExtension extends BaseRegionAwarePluginEx
 	
 	public Optional<Stack> getStack(String stackName) {
 		if (getProject().getGradle().getStartParameter().isOffline() == false) {
-			try {
-				DescribeStacksResult describeStacksResult = getClient().describeStacks(new DescribeStacksRequest()
-					.withStackName(stackName));
-				List<Stack> stacks = describeStacksResult.getStacks();
-				if (stacks.isEmpty() == false) {
-					return stacks.stream().findAny();
-				}
-			} catch (AmazonClientException e) {
-				logger.debug("describeStacks failed", e);
+			DescribeStacksResult describeStacksResult = getClient().describeStacks(new DescribeStacksRequest()
+				.withStackName(stackName));
+			List<Stack> stacks = describeStacksResult.getStacks();
+			if (stacks.isEmpty() == false) {
+				return stacks.stream().findAny();
 			}
 		}
 		return Optional.empty();
@@ -165,14 +161,10 @@ public class AmazonCloudFormationPluginExtension extends BaseRegionAwarePluginEx
 	
 	public List<StackResource> getStackResources(String stackName) {
 		if (getProject().getGradle().getStartParameter().isOffline() == false) {
-			try {
-				DescribeStackResourcesResult describeStackResourcesResult =
-						getClient().describeStackResources(new DescribeStackResourcesRequest()
-							.withStackName(stackName));
-				return describeStackResourcesResult.getStackResources();
-			} catch (AmazonClientException e) {
-				logger.error("describeStackResources failed: {}", e.getMessage());
-			}
+			DescribeStackResourcesResult describeStackResourcesResult =
+					getClient().describeStackResources(new DescribeStackResourcesRequest()
+						.withStackName(stackName));
+			return describeStackResourcesResult.getStackResources();
 		}
 		logger.info("offline mode: return empty resources");
 		return Collections.emptyList();


### PR DESCRIPTION
Remove try/catch in `getStack` and `getStackResources` methods
in `AmazonCloudFormationPluginExtension`.

This is to distinguish the following outcomes:

1. Stack found by name.
2. Stack with this name doesn't exist.
3. Unable to get stack.