### PR TITLE
Update stack no longer requires a template

### DIFF
--- a/src/main/java/jp/classmethod/aws/gradle/cloudformation/AmazonCloudFormationMigrateStackTask.java
+++ b/src/main/java/jp/classmethod/aws/gradle/cloudformation/AmazonCloudFormationMigrateStackTask.java
@@ -130,7 +130,8 @@ public class AmazonCloudFormationMigrateStackTask extends ConventionTask {
 			if (e.getMessage().contains("does not exist")) {
 				getLogger().warn("stack {} not found", stackName);
 				if (cfnTemplateUrl == null && cfnTemplateFile == null) {
-					throw new GradleException("cfnTemplateUrl or cfnTemplateFile must be provided");
+					getLogger().error("cfnTemplateUrl or cfnTemplateFile must be provided");
+					throw e;
 				}
 				createStack(cfn);
 			} else if (e.getMessage().contains("No updates are to be performed.")) {

--- a/src/main/java/jp/classmethod/aws/gradle/cloudformation/AmazonCloudFormationMigrateStackTask.java
+++ b/src/main/java/jp/classmethod/aws/gradle/cloudformation/AmazonCloudFormationMigrateStackTask.java
@@ -21,7 +21,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import com.amazonaws.services.cloudformation.model.*;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -32,6 +31,17 @@ import org.gradle.api.tasks.TaskAction;
 
 import com.amazonaws.AmazonServiceException;
 import com.amazonaws.services.cloudformation.AmazonCloudFormation;
+import com.amazonaws.services.cloudformation.model.Capability;
+import com.amazonaws.services.cloudformation.model.CreateStackRequest;
+import com.amazonaws.services.cloudformation.model.CreateStackResult;
+import com.amazonaws.services.cloudformation.model.DeleteStackRequest;
+import com.amazonaws.services.cloudformation.model.DescribeStacksRequest;
+import com.amazonaws.services.cloudformation.model.DescribeStacksResult;
+import com.amazonaws.services.cloudformation.model.Parameter;
+import com.amazonaws.services.cloudformation.model.Stack;
+import com.amazonaws.services.cloudformation.model.Tag;
+import com.amazonaws.services.cloudformation.model.UpdateStackRequest;
+import com.amazonaws.services.cloudformation.model.UpdateStackResult;
 import com.google.common.base.Strings;
 
 public class AmazonCloudFormationMigrateStackTask extends ConventionTask {

--- a/src/main/java/jp/classmethod/aws/gradle/cloudformation/AmazonCloudFormationMigrateStackTask.java
+++ b/src/main/java/jp/classmethod/aws/gradle/cloudformation/AmazonCloudFormationMigrateStackTask.java
@@ -162,7 +162,7 @@ public class AmazonCloudFormationMigrateStackTask extends ConventionTask {
 			req.setTemplateURL(cfnTemplateUrl);
 			getLogger().info("Using template url: {}", cfnTemplateUrl);
 			// Else, use the template file body
-		} else if (Strings.isNullOrEmpty(cfnTemplateFile) == false) {
+		} else if (cfnStackPolicyFile != null) {
 			req.setTemplateBody(FileUtils.readFileToString(cfnTemplateFile));
 			getLogger().info("Using template file: {}", "$cfnTemplateFile.canonicalPath");
 		} else {

--- a/src/main/java/jp/classmethod/aws/gradle/cloudformation/AmazonCloudFormationMigrateStackTask.java
+++ b/src/main/java/jp/classmethod/aws/gradle/cloudformation/AmazonCloudFormationMigrateStackTask.java
@@ -21,6 +21,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import com.amazonaws.services.cloudformation.model.*;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -31,17 +32,6 @@ import org.gradle.api.tasks.TaskAction;
 
 import com.amazonaws.AmazonServiceException;
 import com.amazonaws.services.cloudformation.AmazonCloudFormation;
-import com.amazonaws.services.cloudformation.model.Capability;
-import com.amazonaws.services.cloudformation.model.CreateStackRequest;
-import com.amazonaws.services.cloudformation.model.CreateStackResult;
-import com.amazonaws.services.cloudformation.model.DeleteStackRequest;
-import com.amazonaws.services.cloudformation.model.DescribeStacksRequest;
-import com.amazonaws.services.cloudformation.model.DescribeStacksResult;
-import com.amazonaws.services.cloudformation.model.Parameter;
-import com.amazonaws.services.cloudformation.model.Stack;
-import com.amazonaws.services.cloudformation.model.Tag;
-import com.amazonaws.services.cloudformation.model.UpdateStackRequest;
-import com.amazonaws.services.cloudformation.model.UpdateStackResult;
 import com.google.common.base.Strings;
 
 public class AmazonCloudFormationMigrateStackTask extends ConventionTask {
@@ -167,6 +157,7 @@ public class AmazonCloudFormationMigrateStackTask extends ConventionTask {
 			req.setTemplateBody(FileUtils.readFileToString(cfnTemplateFile));
 			getLogger().info("Using template file: {}", "$cfnTemplateFile.canonicalPath");
 		} else {
+			req.setUsePreviousTemplate(true);
 			getLogger().info("No template specified, updating existing template");
 		}
 		if (isCapabilityIam()) {

--- a/src/main/java/jp/classmethod/aws/gradle/cloudformation/AmazonCloudFormationMigrateStackTask.java
+++ b/src/main/java/jp/classmethod/aws/gradle/cloudformation/AmazonCloudFormationMigrateStackTask.java
@@ -108,10 +108,6 @@ public class AmazonCloudFormationMigrateStackTask extends ConventionTask {
 		if (stackName == null) {
 			throw new GradleException("stackName is not specified");
 		}
-		if (cfnTemplateUrl == null && cfnTemplateFile == null) {
-			throw new GradleException(
-					"cfnTemplateUrl or cfnTemplateFile must be provided");
-		}
 		
 		AmazonCloudFormationPluginExtension ext =
 				getProject().getExtensions().getByType(AmazonCloudFormationPluginExtension.class);
@@ -133,6 +129,9 @@ public class AmazonCloudFormationMigrateStackTask extends ConventionTask {
 		} catch (AmazonServiceException e) {
 			if (e.getMessage().contains("does not exist")) {
 				getLogger().warn("stack {} not found", stackName);
+				if (cfnTemplateUrl == null && cfnTemplateFile == null) {
+					throw new GradleException("cfnTemplateUrl or cfnTemplateFile must be provided");
+				}
 				createStack(cfn);
 			} else if (e.getMessage().contains("No updates are to be performed.")) {
 				getLogger().trace(e.getMessage());
@@ -163,9 +162,11 @@ public class AmazonCloudFormationMigrateStackTask extends ConventionTask {
 			req.setTemplateURL(cfnTemplateUrl);
 			getLogger().info("Using template url: {}", cfnTemplateUrl);
 			// Else, use the template file body
-		} else {
+		} else if (Strings.isNullOrEmpty(cfnTemplateFile) == false) {
 			req.setTemplateBody(FileUtils.readFileToString(cfnTemplateFile));
 			getLogger().info("Using template file: {}", "$cfnTemplateFile.canonicalPath");
+		} else {
+			getLogger().info("No template specified, updating existing template");
 		}
 		if (isCapabilityIam()) {
 			Capability selectedCapability =


### PR DESCRIPTION
The SDK no longer requires a CFN template when performing an update.  This would make it so on an update you can just use the existing template.

