### PR TITLE
Specify client Region for STS Client for cn-north-1

### DIFF
--- a/src/main/java/jp/classmethod/aws/gradle/AwsPluginExtension.java
+++ b/src/main/java/jp/classmethod/aws/gradle/AwsPluginExtension.java
@@ -147,11 +147,13 @@ public class AwsPluginExtension {
 	
 	public String getAccountId() {
 		AWSSecurityTokenService sts = createClient(AWSSecurityTokenServiceClient.class, profileName);
+		sts.setRegion(getActiveRegion(region));
 		return sts.getCallerIdentity(new GetCallerIdentityRequest()).getAccount();
 	}
 	
 	public String getUserArn() {
 		AWSSecurityTokenService sts = createClient(AWSSecurityTokenServiceClient.class, profileName);
+		sts.setRegion(getActiveRegion(region));
 		return sts.getCallerIdentity(new GetCallerIdentityRequest()).getArn();
 	}
 }


### PR DESCRIPTION
AWS China region(`cn-north-1`) uses different endpoint TLD from other regions, shown in the following document. 

- http://docs.amazonaws.cn/en_us/general/latest/gr/rande.html#cnnorth_region

This plugin currently does not set region parameter for the *global* AWS services, like IAM/STS. But this makes problem when it comes to cn-north-1.

This PR sets STS client region to the user-specified region. By default, STS Client region is set to `us-east-1` . Setting STS region to another(e.g. us-west-2) does not affect any behavior of the plugin(except in the case when you provided cn-north-1 accidentally).