### PR TITLE
To handle the case where the aws ecr repository already exists and handle the exception returning the current ecr repository information.

### DIFF
--- a/src/main/java/jp/classmethod/aws/gradle/ecr/AmazonECRCreateRepositoryTask.java
+++ b/src/main/java/jp/classmethod/aws/gradle/ecr/AmazonECRCreateRepositoryTask.java
@@ -52,12 +52,13 @@ public class AmazonECRCreateRepositoryTask extends ConventionTask {
 		
 		String repositoryName = MoreObjects.firstNonNull(getRepositoryName(), ext.getRepositoryName());
 
-		try
-		{
-			CreateRepositoryResult result = ecr.createRepository(new CreateRepositoryRequest().withRepositoryName(repositoryName));
+		try {
+			CreateRepositoryResult result = ecr.createRepository(new CreateRepositoryRequest().
+					withRepositoryName(repositoryName));
 			repository = result.getRepository();
 		} catch (RepositoryAlreadyExistsException ex) {
-			DescribeRepositoriesResult describeRepositoriesResult = ecr.describeRepositories(new DescribeRepositoriesRequest());
+			DescribeRepositoriesResult describeRepositoriesResult =
+					ecr.describeRepositories(new DescribeRepositoriesRequest());
 			for (Repository repositoryResult : describeRepositoriesResult.getRepositories()) {
 				if (repositoryResult.getRepositoryName().equals(repositoryName)) {
 					repository = repositoryResult;

--- a/src/main/java/jp/classmethod/aws/gradle/ecr/AmazonECRCreateRepositoryTask.java
+++ b/src/main/java/jp/classmethod/aws/gradle/ecr/AmazonECRCreateRepositoryTask.java
@@ -15,9 +15,6 @@
  */
 package jp.classmethod.aws.gradle.ecr;
 
-import com.amazonaws.services.ecr.model.DescribeRepositoriesRequest;
-import com.amazonaws.services.ecr.model.DescribeRepositoriesResult;
-import com.amazonaws.services.ecr.model.RepositoryAlreadyExistsException;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -27,7 +24,10 @@ import org.gradle.api.tasks.TaskAction;
 import com.amazonaws.services.ecr.AmazonECR;
 import com.amazonaws.services.ecr.model.CreateRepositoryRequest;
 import com.amazonaws.services.ecr.model.CreateRepositoryResult;
+import com.amazonaws.services.ecr.model.DescribeRepositoriesRequest;
+import com.amazonaws.services.ecr.model.DescribeRepositoriesResult;
 import com.amazonaws.services.ecr.model.Repository;
+import com.amazonaws.services.ecr.model.RepositoryAlreadyExistsException;
 import com.google.common.base.MoreObjects;
 
 public class AmazonECRCreateRepositoryTask extends ConventionTask {
@@ -51,10 +51,10 @@ public class AmazonECRCreateRepositoryTask extends ConventionTask {
 		AmazonECR ecr = ext.getClient();
 		
 		String repositoryName = MoreObjects.firstNonNull(getRepositoryName(), ext.getRepositoryName());
-
+		
 		try {
-			CreateRepositoryResult result = ecr.createRepository(new CreateRepositoryRequest().
-					withRepositoryName(repositoryName));
+			CreateRepositoryResult result =
+					ecr.createRepository(new CreateRepositoryRequest().withRepositoryName(repositoryName));
 			repository = result.getRepository();
 		} catch (RepositoryAlreadyExistsException ex) {
 			DescribeRepositoriesResult describeRepositoriesResult =


### PR DESCRIPTION
If the ECR repository exists then currently the plugin will fail with an error however it should handle this case by returning the existing repository information as part of the build task.