### PR TITLE
Allow json comments in beanstalk configuration templates

### DIFF
--- a/src/main/java/jp/classmethod/aws/gradle/elasticbeanstalk/AWSElasticBeanstalkCreateConfigurationTemplateTask.java
+++ b/src/main/java/jp/classmethod/aws/gradle/elasticbeanstalk/AWSElasticBeanstalkCreateConfigurationTemplateTask.java
@@ -35,6 +35,8 @@ import com.amazonaws.services.elasticbeanstalk.model.DeleteConfigurationTemplate
 import com.amazonaws.services.elasticbeanstalk.model.DescribeApplicationsRequest;
 import com.amazonaws.services.elasticbeanstalk.model.UpdateConfigurationTemplateRequest;
 
+import groovy.json.JsonParserType;
+
 public class AWSElasticBeanstalkCreateConfigurationTemplateTask extends ConventionTask {
 	
 	@Getter
@@ -112,7 +114,8 @@ public class AWSElasticBeanstalkCreateConfigurationTemplateTask extends Conventi
 		List<ConfigurationOptionSetting> options = new ArrayList<>();
 		@SuppressWarnings("unchecked")
 		Collection<Map<String, Object>> c =
-				(Collection<Map<String, Object>>) new groovy.json.JsonSlurper().parseText(json);
+				(Collection<Map<String, Object>>) new groovy.json.JsonSlurper().setType(JsonParserType.LAX)
+					.parseText(json);
 		c.forEach(it -> options.add(new ConfigurationOptionSetting((String) it.get("Namespace"),
 				(String) it.get("OptionName"), (String) it.get("Value"))));
 		return options;


### PR DESCRIPTION
Templates can get disordered. Using the lax json parser type allows the use of
java script comments inside the json of the beanstalk configuration templates.

```
[
  { "Namespace" : "aws:autoscaling:launchconfiguration", "OptionName" : "InstanceType", "Value" : "t2.micro" },

  /* Scaling */
  { "Namespace" : "aws:elasticbeanstalk:environment", "OptionName" : "EnvironmentType", "Value" : "LoadBalanced" },
  { "Namespace" : "aws:autoscaling:asg", "OptionName" : "MinSize", "Value" : "1" },
  { "Namespace" : "aws:autoscaling:asg", "OptionName" : "MaxSize", "Value" : "5" },
]
```