### PR TITLE
Lambda Publish Version, Create Alias and Update Alias tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,9 @@ Current Features / Supported AWS Products
   * Migrate (create or update) function
   * Invoke function
   * Delete function
+  * Publish function version
+  * Create alias
+  * Update alias
 * IAM
   * Create role
   * Attach role policy
@@ -322,6 +325,26 @@ task invokeFunction(type: AWSLambdaInvokeTask) {
 
 task deleteFunction(type: AWSLambdaDeleteFunctionTask) {
 	functionName = "foobar"
+}
+
+task publishVersionFunction(type: AWSLambdaPublishVersionTask, dependsOn: migrateFunction) {
+	functionName = "foobar"
+}
+
+task createAlias(type: AWSLambdaCreateAliasTask, dependsOn: publishVersionFunction) {
+	functionName = "foobar"
+	aliasName = "alias"
+	functionVersion = "1"
+}
+
+task updateAlias(type: AWSLambdaUpdateAliasTask, dependsOn: createAlias) {
+	functionName = "foobar"
+    aliasName = "alias"
+	functionVersion = "1"
+    routingConfig {
+        additionalVersionWeight = 0.7
+		useNextVersion = true
+    }
 }
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -202,7 +202,7 @@ configurations {
 // ======== library versions ========
 ext {
 	lombokVersion = "1.16.2"
-	awsJavaSdkVersion = "1.11.86"
+	awsJavaSdkVersion = "1.11.264"
 	groovyVersion = "2.3.7"
 	junitVersion = "4.12"
 	hamcrestVersion = "1.3"

--- a/samples/08-lambda/build.gradle
+++ b/samples/08-lambda/build.gradle
@@ -84,7 +84,7 @@ task publishVersionFunction(type: AWSLambdaPublishVersionTask, dependsOn: migrat
 	functionName = "foobar"
 }
 
-task createAlias(type: AWSLambdaCreateAliasTask, dependsOn: AWSLambdaPublishVersionTask) {
+task createAlias(type: AWSLambdaCreateAliasTask, dependsOn: publishVersionFunction) {
 	functionName = "foobar"
 	aliasName = "alias"
 	functionVersion = "1"

--- a/samples/08-lambda/build.gradle
+++ b/samples/08-lambda/build.gradle
@@ -5,6 +5,10 @@ import com.amazonaws.services.lambda.model.InvocationType;
 import jp.classmethod.aws.gradle.lambda.AWSLambdaDeleteFunctionTask;
 import jp.classmethod.aws.gradle.lambda.AWSLambdaInvokeTask;
 import jp.classmethod.aws.gradle.lambda.AWSLambdaMigrateFunctionTask;
+import jp.classmethod.aws.gradle.lambda.AWSLambdaPublishVersionTask;
+import jp.classmethod.aws.gradle.lambda.AWSLambdaCreateAliasTask;
+import jp.classmethod.aws.gradle.lambda.AWSLambdaUpdateAliasTask;
+
 import jp.classmethod.aws.gradle.lambda.VpcConfigWrapper
 
 buildscript {
@@ -76,3 +80,22 @@ task deleteFunction(type: AWSLambdaDeleteFunctionTask) {
 	functionName = "foobar"
 }
 
+task publishVersionFunction(type: AWSLambdaPublishVersionTask, dependsOn: migrateFunction) {
+	functionName = "foobar"
+}
+
+task createAlias(type: AWSLambdaCreateAliasTask, dependsOn: AWSLambdaPublishVersionTask) {
+	functionName = "foobar"
+	aliasName = "alias"
+	functionVersion = "1"
+}
+
+task updateAlias(type: AWSLambdaUpdateAliasTask, dependsOn: createAlias) {
+	functionName = "foobar"
+    aliasName = "alias"
+	functionVersion = "1"
+    routingConfig {
+        additionalVersionWeight = 0.7
+		useNextVersion = true
+    }
+}

--- a/src/main/java/jp/classmethod/aws/gradle/lambda/AWSLambdaCreateAliasTask.java
+++ b/src/main/java/jp/classmethod/aws/gradle/lambda/AWSLambdaCreateAliasTask.java
@@ -107,7 +107,7 @@ public class AWSLambdaCreateAliasTask extends ConventionTask {
 			final RoutingConfig routingConfig = getRoutingConfig();
 			
 			final AliasRoutingConfiguration aliasRoutingConfiguration =
-					routingConfig.getAliasRoutingConfiguration(lambda, functionName, functionVersion);
+					routingConfig.getAliasRoutingConfiguration(functionName, functionVersion);
 			
 			request.withRoutingConfig(aliasRoutingConfiguration);
 		}

--- a/src/main/java/jp/classmethod/aws/gradle/lambda/AWSLambdaCreateAliasTask.java
+++ b/src/main/java/jp/classmethod/aws/gradle/lambda/AWSLambdaCreateAliasTask.java
@@ -22,7 +22,6 @@ import lombok.Setter;
 
 import org.gradle.api.GradleException;
 import org.gradle.api.internal.ConventionTask;
-import org.gradle.api.tasks.Nested;
 import org.gradle.api.tasks.TaskAction;
 
 import com.amazonaws.services.lambda.AWSLambda;

--- a/src/main/java/jp/classmethod/aws/gradle/lambda/AWSLambdaCreateAliasTask.java
+++ b/src/main/java/jp/classmethod/aws/gradle/lambda/AWSLambdaCreateAliasTask.java
@@ -1,97 +1,131 @@
+/*
+ * Copyright 2015-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package jp.classmethod.aws.gradle.lambda;
+
+import static groovy.lang.Closure.DELEGATE_FIRST;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import org.gradle.api.GradleException;
+import org.gradle.api.internal.ConventionTask;
+import org.gradle.api.tasks.Nested;
+import org.gradle.api.tasks.TaskAction;
 
 import com.amazonaws.services.lambda.AWSLambda;
 import com.amazonaws.services.lambda.model.AliasRoutingConfiguration;
 import com.amazonaws.services.lambda.model.CreateAliasRequest;
 import com.amazonaws.services.lambda.model.CreateAliasResult;
-import com.amazonaws.services.lambda.model.UpdateAliasResult;
-import lombok.Getter;
-import lombok.Setter;
-import org.gradle.api.GradleException;
-import org.gradle.api.internal.ConventionTask;
-import org.gradle.api.tasks.TaskAction;
+
+import groovy.lang.Closure;
 
 /**
  * Created by frankfarrell on 16/01/2018.
  * https://docs.aws.amazon.com/cli/latest/reference/lambda/create-alias.html
  */
-public class AWSLambdaCreateAliasTask  extends ConventionTask {
-
-    /*
-    The function name for which the alias is created.
-    Note that the length constraint applies only to the ARN.
-    If you specify only the function name, it is limited to 64 characters in length.
-     */
-    @Getter
-    @Setter
-    private String functionName;
-
-    @Getter
-    @Setter
-    private String name;
-
-    /*
-    Using this parameter you can change the Lambda function version to which the alias points.
-    If you do not specify it, the alias will point by default to $LATEST
-     */
-    @Getter
-    @Setter
-    private String functionVersion;
-
-    /*
-    You can change the description of the alias using this parameter.
-    */
-    @Getter
-    @Setter
-    private String aliasDescription;
-    /*
-    https://docs.aws.amazon.com/lambda/latest/dg/lambda-traffic-shifting-using-aliases.html
-     */
-    @Getter
-    @Setter
-    private RoutingConfig routingConfig;
-
-    @Getter
-    private CreateAliasResult createAliasResult;
-
-    @TaskAction
-    public void createAlias() {
-        final String functionName = getFunctionName();
-        final String aliasName = getName();
-        final String functionVersion = getFunctionVersion();
-
-        if (functionName == null) {
-            throw new GradleException("functionName is required");
-        }
-        if (aliasName == null) {
-            throw new GradleException("name for alias is required");
-        }
-        if (functionVersion == null) {
-            throw new GradleException("functionVersion for alias is required");
-        }
-
-        final CreateAliasRequest request = new CreateAliasRequest().withFunctionName(functionName)
-                .withFunctionVersion(functionVersion)
-                .withName(aliasName);
-
-        final AWSLambda lambda = getAwsLambdaClient();
-
-        if(getDescription() != null){
-            request.withDescription(getDescription());
-        }
-        if(getRoutingConfig() != null){
-            final RoutingConfig routingConfig = getRoutingConfig();
-
-            final AliasRoutingConfiguration aliasRoutingConfiguration = routingConfig.getAliasRoutingConfiguration(lambda, functionName, functionVersion);
-
-            request.withRoutingConfig(aliasRoutingConfiguration);
-        }
-
-        createAliasResult = lambda.createAlias(request);
-    }
-
-    private AWSLambda getAwsLambdaClient() {
-        final AWSLambdaPluginExtension ext = getProject().getExtensions().getByType(AWSLambdaPluginExtension.class);
-        return ext.getClient();
-    }
+public class AWSLambdaCreateAliasTask extends ConventionTask {
+	
+	/*
+	The function name for which the alias is created.
+	Note that the length constraint applies only to the ARN.
+	If you specify only the function name, it is limited to 64 characters in length.
+	 */
+	@Getter
+	@Setter
+	private String functionName;
+	
+	@Getter
+	@Setter
+	private String aliasName;
+	
+	/*
+	Using this parameter you can change the Lambda function version to which the alias points.
+	If you do not specify it, the alias will point by default to $LATEST
+	 */
+	@Getter
+	@Setter
+	private String functionVersion;
+	
+	/*
+	You can change the description of the alias using this parameter.
+	 */
+	@Getter
+	@Setter
+	private String aliasDescription;
+	
+	/*
+	https://docs.aws.amazon.com/lambda/latest/dg/lambda-traffic-shifting-using-aliases.html
+	 */
+	@Getter
+	@Setter
+	private RoutingConfig routingConfig;
+	
+	@Getter
+	private CreateAliasResult createAliasResult;
+	
+	
+	@TaskAction
+	public void createAlias() {
+		final String functionName = getFunctionName();
+		final String aliasName = getAliasName();
+		final String functionVersion = getFunctionVersion();
+		
+		if (functionName == null) {
+			throw new GradleException("functionName is required");
+		}
+		if (aliasName == null) {
+			throw new GradleException("name for alias is required");
+		}
+		if (functionVersion == null) {
+			throw new GradleException("functionVersion for alias is required");
+		}
+		
+		final CreateAliasRequest request = new CreateAliasRequest()
+			.withFunctionName(functionName)
+			.withFunctionVersion(functionVersion)
+			.withName(aliasName);
+		
+		final AWSLambda lambda = getAwsLambdaClient();
+		
+		if (getDescription() != null) {
+			request.withDescription(getDescription());
+		}
+		if (getRoutingConfig() != null) {
+			final RoutingConfig routingConfig = getRoutingConfig();
+			
+			final AliasRoutingConfiguration aliasRoutingConfiguration =
+					routingConfig.getAliasRoutingConfiguration(lambda, functionName, functionVersion);
+			
+			request.withRoutingConfig(aliasRoutingConfiguration);
+		}
+		
+		createAliasResult = lambda.createAlias(request);
+	}
+	
+	private AWSLambda getAwsLambdaClient() {
+		final AWSLambdaPluginExtension ext = getProject().getExtensions().getByType(AWSLambdaPluginExtension.class);
+		return ext.getClient();
+	}
+	
+	public void routingConfig(final Closure<RoutingConfig> c) {
+		c.setResolveStrategy(DELEGATE_FIRST);
+		if (routingConfig == null) {
+			routingConfig = new RoutingConfig();
+		}
+		c.setDelegate(routingConfig);
+		c.call();
+	}
 }

--- a/src/main/java/jp/classmethod/aws/gradle/lambda/AWSLambdaPublishVersionTask.java
+++ b/src/main/java/jp/classmethod/aws/gradle/lambda/AWSLambdaPublishVersionTask.java
@@ -1,0 +1,68 @@
+package jp.classmethod.aws.gradle.lambda;
+
+import com.amazonaws.services.lambda.AWSLambda;
+import com.amazonaws.services.lambda.model.PublishVersionRequest;
+import com.amazonaws.services.lambda.model.PublishVersionResult;
+import lombok.Getter;
+import lombok.Setter;
+import org.gradle.api.GradleException;
+import org.gradle.api.internal.ConventionTask;
+import org.gradle.api.tasks.TaskAction;
+
+/**
+ * Created by frankfarrell on 16/01/2018.
+ *
+ * https://docs.aws.amazon.com/cli/latest/reference/lambda/publish-version.html
+ */
+public class AWSLambdaPublishVersionTask extends ConventionTask {
+
+    /*
+    The function name for which the alias is created.
+    Note that the length constraint applies only to the ARN.
+    If you specify only the function name, it is limited to 64 characters in length.
+     */
+    @Getter
+    @Setter
+    private String functionName;
+
+    @Getter
+    @Setter
+    private String codeSha256;
+
+    @Getter
+    @Setter
+    private String description;
+
+    @Getter
+    private PublishVersionResult publishVersionResult;
+
+    @TaskAction
+    public void publishVersion(){
+
+        final String functionName = getFunctionName();
+
+        if (functionName == null) {
+            throw new GradleException("functionName is required");
+        }
+
+        final AWSLambda lambda = getAwsLambdaClient();
+
+        PublishVersionRequest request = new PublishVersionRequest().withFunctionName(functionName);
+
+        if(getCodeSha256() != null){
+            request.withCodeSha256(getCodeSha256());
+        }
+        if(getDescription() != null){
+            request.withDescription(getDescription());
+        }
+
+        publishVersionResult = lambda.publishVersion(request);
+
+        getLogger().info("Publish lambda version for {} succeded with version {}", functionName, publishVersionResult.getVersion());
+    }
+
+    private AWSLambda getAwsLambdaClient() {
+        final AWSLambdaPluginExtension ext = getProject().getExtensions().getByType(AWSLambdaPluginExtension.class);
+        return ext.getClient();
+    }
+}

--- a/src/main/java/jp/classmethod/aws/gradle/lambda/AWSLambdaPublishVersionTask.java
+++ b/src/main/java/jp/classmethod/aws/gradle/lambda/AWSLambdaPublishVersionTask.java
@@ -1,13 +1,30 @@
+/*
+ * Copyright 2015-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package jp.classmethod.aws.gradle.lambda;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import org.gradle.api.GradleException;
+import org.gradle.api.internal.ConventionTask;
+import org.gradle.api.tasks.TaskAction;
 
 import com.amazonaws.services.lambda.AWSLambda;
 import com.amazonaws.services.lambda.model.PublishVersionRequest;
 import com.amazonaws.services.lambda.model.PublishVersionResult;
-import lombok.Getter;
-import lombok.Setter;
-import org.gradle.api.GradleException;
-import org.gradle.api.internal.ConventionTask;
-import org.gradle.api.tasks.TaskAction;
 
 /**
  * Created by frankfarrell on 16/01/2018.
@@ -15,54 +32,57 @@ import org.gradle.api.tasks.TaskAction;
  * https://docs.aws.amazon.com/cli/latest/reference/lambda/publish-version.html
  */
 public class AWSLambdaPublishVersionTask extends ConventionTask {
-
-    /*
-    The function name for which the alias is created.
-    Note that the length constraint applies only to the ARN.
-    If you specify only the function name, it is limited to 64 characters in length.
-     */
-    @Getter
-    @Setter
-    private String functionName;
-
-    @Getter
-    @Setter
-    private String codeSha256;
-
-    @Getter
-    @Setter
-    private String description;
-
-    @Getter
-    private PublishVersionResult publishVersionResult;
-
-    @TaskAction
-    public void publishVersion(){
-
-        final String functionName = getFunctionName();
-
-        if (functionName == null) {
-            throw new GradleException("functionName is required");
-        }
-
-        final AWSLambda lambda = getAwsLambdaClient();
-
-        PublishVersionRequest request = new PublishVersionRequest().withFunctionName(functionName);
-
-        if(getCodeSha256() != null){
-            request.withCodeSha256(getCodeSha256());
-        }
-        if(getDescription() != null){
-            request.withDescription(getDescription());
-        }
-
-        publishVersionResult = lambda.publishVersion(request);
-
-        getLogger().info("Publish lambda version for {} succeded with version {}", functionName, publishVersionResult.getVersion());
-    }
-
-    private AWSLambda getAwsLambdaClient() {
-        final AWSLambdaPluginExtension ext = getProject().getExtensions().getByType(AWSLambdaPluginExtension.class);
-        return ext.getClient();
-    }
+	
+	/*
+	The function name for which the alias is created.
+	Note that the length constraint applies only to the ARN.
+	If you specify only the function name, it is limited to 64 characters in length.
+	 */
+	@Getter
+	@Setter
+	private String functionName;
+	
+	@Getter
+	@Setter
+	private String codeSha256;
+	
+	@Getter
+	@Setter
+	private String description;
+	
+	@Getter
+	private PublishVersionResult publishVersionResult;
+	
+	
+	@TaskAction
+	public void publishVersion() {
+		
+		final String functionName = getFunctionName();
+		
+		if (functionName == null) {
+			throw new GradleException("functionName is required");
+		}
+		
+		final AWSLambda lambda = getAwsLambdaClient();
+		
+		PublishVersionRequest request = new PublishVersionRequest().withFunctionName(functionName);
+		
+		if (getCodeSha256() != null) {
+			request.withCodeSha256(getCodeSha256());
+		}
+		if (getDescription() != null) {
+			request.withDescription(getDescription());
+		}
+		
+		publishVersionResult = lambda.publishVersion(request);
+		
+		getLogger().info("Publish lambda version for {} succeeded with version {}",
+				functionName,
+				publishVersionResult.getVersion());
+	}
+	
+	private AWSLambda getAwsLambdaClient() {
+		final AWSLambdaPluginExtension ext = getProject().getExtensions().getByType(AWSLambdaPluginExtension.class);
+		return ext.getClient();
+	}
 }

--- a/src/main/java/jp/classmethod/aws/gradle/lambda/AWSLambdaUpdateAliasTask.java
+++ b/src/main/java/jp/classmethod/aws/gradle/lambda/AWSLambdaUpdateAliasTask.java
@@ -1,16 +1,36 @@
+/*
+ * Copyright 2015-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package jp.classmethod.aws.gradle.lambda;
 
-import com.amazonaws.services.lambda.AWSLambda;
-import com.amazonaws.services.lambda.model.*;
+import static groovy.lang.Closure.DELEGATE_FIRST;
+
 import lombok.Getter;
 import lombok.Setter;
+
 import org.gradle.api.GradleException;
 import org.gradle.api.internal.ConventionTask;
+import org.gradle.api.tasks.Nested;
 import org.gradle.api.tasks.TaskAction;
 
-import java.util.Collections;
-import java.util.List;
-import java.util.stream.Collectors;
+import com.amazonaws.services.lambda.AWSLambda;
+import com.amazonaws.services.lambda.model.AliasRoutingConfiguration;
+import com.amazonaws.services.lambda.model.UpdateAliasRequest;
+import com.amazonaws.services.lambda.model.UpdateAliasResult;
+
+import groovy.lang.Closure;
 
 /**
  * Created by frankfarrell on 16/01/2018.
@@ -18,90 +38,103 @@ import java.util.stream.Collectors;
  * https://docs.aws.amazon.com/cli/latest/reference/lambda/update-alias.html
  */
 public class AWSLambdaUpdateAliasTask extends ConventionTask {
-
-    /*
-    The function name for which the alias is created.
-    Note that the length constraint applies only to the ARN.
-    If you specify only the function name, it is limited to 64 characters in length.
-     */
-    @Getter
-    @Setter
-    private String functionName;
-
-    @Getter
-    @Setter
-    private String name;
-
-    /*
-    Using this parameter you can change the Lambda function version to which the alias points.
-    If you do not specify it, the alias will point by default to $LATEST
-     */
-    @Getter
-    @Setter
-    private String functionVersion;
-
-    /*
-    You can change the description of the alias using this parameter.
-    */
-    @Getter
-    @Setter
-    private String aliasDescription;
-    /*
-    https://docs.aws.amazon.com/lambda/latest/dg/lambda-traffic-shifting-using-aliases.html
-     */
-    @Getter
-    @Setter
-    private RoutingConfig routingConfig;
-
-    @Getter
-    private UpdateAliasResult updateAliasResult;
-
-
-    public AWSLambdaUpdateAliasTask() {
-        setDescription("Update Lambda Alias");
-        setGroup("AWS");
-    }
-
-    @TaskAction
-    public void updateFunctionAlias(){
-
-        final String functionName = getFunctionName();
-        final String aliasName = getName();
-
-        if (functionName == null) {
-            throw new GradleException("functionName is required");
-        }
-        if (aliasName == null) {
-            throw new GradleException("name for alias is required");
-        }
-
-        final AWSLambda lambda = getAwsLambdaClient();
-
-        final UpdateAliasRequest updateAliasRequest = new UpdateAliasRequest()
-                .withFunctionName(functionName)
-                .withName(aliasName);
-
-        if(getFunctionVersion() != null){
-            updateAliasRequest.withFunctionVersion(getFunctionVersion());
-        }
-        if(getDescription() != null){
-            updateAliasRequest.withDescription(getDescription());
-        }
-        if(getRoutingConfig() != null){
-            final RoutingConfig routingConfig = getRoutingConfig();
-
-            final AliasRoutingConfiguration aliasRoutingConfiguration = routingConfig.getAliasRoutingConfiguration(lambda, functionName, functionVersion);
-
-            updateAliasRequest.withRoutingConfig(aliasRoutingConfiguration);
-        }
-
-        updateAliasResult = lambda.updateAlias(updateAliasRequest);
-        getLogger().info("Update Lambda alias requested: {}, name: {}", functionName, aliasName);
-    }
-
-
-    private AWSLambda getAwsLambdaClient() {
-        final AWSLambdaPluginExtension ext = getProject().getExtensions().getByType(AWSLambdaPluginExtension.class);
-        return ext.getClient();
-    }
+	
+	/*
+	The function name for which the alias is created.
+	Note that the length constraint applies only to the ARN.
+	If you specify only the function name, it is limited to 64 characters in length.
+	 */
+	@Getter
+	@Setter
+	private String functionName;
+	
+	@Getter
+	@Setter
+	private String aliasName;
+	
+	/*
+	Using this parameter you can change the Lambda function version to which the alias points.
+	If you do not specify it, the alias will point by default to $LATEST
+	 */
+	@Getter
+	@Setter
+	private String functionVersion;
+	
+	/*
+	You can change the description of the alias using this parameter.
+	 */
+	@Getter
+	@Setter
+	private String aliasDescription;
+	
+	/*
+	https://docs.aws.amazon.com/lambda/latest/dg/lambda-traffic-shifting-using-aliases.html
+	 */
+	@Nested
+	@Getter
+	@Setter
+	private RoutingConfig routingConfig;
+	
+	@Getter
+	private UpdateAliasResult updateAliasResult;
+	
+	
+	public AWSLambdaUpdateAliasTask() {
+		setDescription("Update Lambda Alias");
+		setGroup("AWS");
+	}
+	
+	@TaskAction
+	public void updateFunctionAlias() {
+		
+		final String functionName = getFunctionName();
+		final String aliasName = getAliasName();
+		
+		if (functionName == null) {
+			throw new GradleException("functionName is required");
+		}
+		if (aliasName == null) {
+			throw new GradleException("name for alias is required");
+		}
+		
+		final AWSLambda lambda = getAwsLambdaClient();
+		
+		final UpdateAliasRequest updateAliasRequest = new UpdateAliasRequest()
+			.withFunctionName(functionName)
+			.withName(aliasName);
+		
+		if (getFunctionVersion() != null) {
+			updateAliasRequest.withFunctionVersion(getFunctionVersion());
+		}
+		if (getDescription() != null) {
+			updateAliasRequest.withDescription(getDescription());
+		}
+		if (getRoutingConfig() != null) {
+			final RoutingConfig routingConfig = getRoutingConfig();
+			
+			final AliasRoutingConfiguration aliasRoutingConfiguration =
+					routingConfig.getAliasRoutingConfiguration(lambda,
+							functionName,
+							functionVersion);
+			
+			updateAliasRequest.withRoutingConfig(aliasRoutingConfiguration);
+		}
+		
+		updateAliasResult = lambda.updateAlias(updateAliasRequest);
+		getLogger().info("Update Lambda alias requested: {}, name: {}", functionName, aliasName);
+	}
+	
+	private AWSLambda getAwsLambdaClient() {
+		final AWSLambdaPluginExtension ext = getProject().getExtensions().getByType(AWSLambdaPluginExtension.class);
+		return ext.getClient();
+	}
+	
+	public void routingConfig(final Closure<RoutingConfig> c) {
+		c.setResolveStrategy(DELEGATE_FIRST);
+		if (routingConfig == null) {
+			routingConfig = new RoutingConfig();
+		}
+		c.setDelegate(routingConfig);
+		c.call();
+	}
 }

--- a/src/main/java/jp/classmethod/aws/gradle/lambda/AWSLambdaUpdateAliasTask.java
+++ b/src/main/java/jp/classmethod/aws/gradle/lambda/AWSLambdaUpdateAliasTask.java
@@ -113,9 +113,8 @@ public class AWSLambdaUpdateAliasTask extends ConventionTask {
 			final RoutingConfig routingConfig = getRoutingConfig();
 			
 			final AliasRoutingConfiguration aliasRoutingConfiguration =
-					routingConfig.getAliasRoutingConfiguration(lambda,
-							functionName,
-							functionVersion);
+					routingConfig.getAliasRoutingConfiguration(functionName,
+							getFunctionVersion());
 			
 			updateAliasRequest.withRoutingConfig(aliasRoutingConfiguration);
 		}

--- a/src/main/java/jp/classmethod/aws/gradle/lambda/AWSLambdaUpdateAliasTask.java
+++ b/src/main/java/jp/classmethod/aws/gradle/lambda/AWSLambdaUpdateAliasTask.java
@@ -1,0 +1,165 @@
+package jp.classmethod.aws.gradle.lambda;
+
+import com.amazonaws.services.lambda.AWSLambda;
+import com.amazonaws.services.lambda.model.*;
+import lombok.Getter;
+import lombok.Setter;
+import org.gradle.api.GradleException;
+import org.gradle.api.internal.ConventionTask;
+import org.gradle.api.tasks.TaskAction;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Created by frankfarrell on 16/01/2018.
+ *
+ * https://docs.aws.amazon.com/cli/latest/reference/lambda/update-alias.html
+ */
+public class AWSLambdaUpdateAliasTask extends ConventionTask {
+
+    /*
+    The function name for which the alias is created.
+    Note that the length constraint applies only to the ARN.
+    If you specify only the function name, it is limited to 64 characters in length.
+     */
+    @Getter
+    @Setter
+    private String functionName;
+
+    @Getter
+    @Setter
+    private String name;
+
+    /*
+    Using this parameter you can change the Lambda function version to which the alias points.
+    If you do not specify it, the alias will point by default to $LATEST
+     */
+    @Getter
+    @Setter
+    private String functionVersion;
+
+    /*
+    You can change the description of the alias using this parameter.
+    */
+    @Getter
+    @Setter
+    private String aliasDescription;
+    /*
+    https://docs.aws.amazon.com/lambda/latest/dg/lambda-traffic-shifting-using-aliases.html
+     */
+    @Getter
+    @Setter
+    private RoutingConfig routingConfig;
+
+    @Getter
+    private UpdateAliasResult updateAliasResult;
+
+
+    public AWSLambdaUpdateAliasTask() {
+        setDescription("Update Lambda Alias");
+        setGroup("AWS");
+    }
+
+    @TaskAction
+    public void aupdateFunctionAlias(){
+        // to enable conventionMappings feature
+        final String functionName = getFunctionName();
+        final String aliasName = getName();
+
+        if (functionName == null) {
+            throw new GradleException("functionName is required");
+        }
+        if (aliasName == null) {
+            throw new GradleException("name for alias is required");
+        }
+
+        final AWSLambda lambda = getAwsLambdaClient();
+
+        final UpdateAliasRequest updateAliasRequest = new UpdateAliasRequest()
+                .withFunctionName(functionName)
+                .withName(aliasName);
+
+        if(getFunctionVersion() != null){
+            updateAliasRequest.withFunctionVersion(getFunctionVersion());
+        }
+        if(getDescription() != null){
+            updateAliasRequest.withDescription(getDescription());
+        }
+        if(getRoutingConfig() != null){
+            final RoutingConfig routingConfig = getRoutingConfig();
+
+            if(routingConfig.getAdditionalVersionWeight() == null){
+                throw new GradleException("Additional Version Weight for routing config is required");
+            }
+            if(routingConfig.getAdditionalVersion() == null ||
+                    routingConfig.getUsePreviousVersion() == null ||
+                    routingConfig.getUseNextVersion() ==null){
+                throw new GradleException("Exactly one of AdditionalVersion, UsePreviousVersion, UseNextVersion for routing config is required");
+            }
+
+            final Double additionalVersionWeight = routingConfig.getAdditionalVersionWeight();
+
+
+            final AliasRoutingConfiguration aliasRoutingConfiguration = new AliasRoutingConfiguration();
+
+            if(routingConfig.getAdditionalVersion() != null){
+                aliasRoutingConfiguration.withAdditionalVersionWeights(Collections.singletonMap(routingConfig.getAdditionalVersion(), additionalVersionWeight));
+            }
+            else if(routingConfig.getUsePreviousVersion() != null){
+                final String prevVersion = getPreviousVersion(functionName, getFunctionVersion());
+                aliasRoutingConfiguration.withAdditionalVersionWeights(Collections.singletonMap(prevVersion, additionalVersionWeight));
+            }
+            else{
+                final String nextVersion = getNextVersion(functionName, getFunctionVersion());
+                aliasRoutingConfiguration.withAdditionalVersionWeights(Collections.singletonMap(nextVersion, additionalVersionWeight));
+            }
+            updateAliasRequest.withRoutingConfig(aliasRoutingConfiguration);
+        }
+
+        updateAliasResult = lambda.updateAlias(updateAliasRequest);
+        getLogger().info("Update Lambda alias requested: {}, name: {}", functionName, aliasName);
+    }
+
+    private String getNextVersion(final String functionName, final String functionVersion) {
+        final List<String> versions = getFunctionVersions(functionName);
+
+        for(int i=1;i<versions.size();i++){
+            if(versions.get(i).equals(functionVersion)){
+                getLogger().info("Next version after {} is {}", functionVersion, versions.get(i-1));
+                return versions.get(i-1);
+            }
+        }
+        throw new GradleException("There is no newer version than " + functionName);
+    }
+
+    private String getPreviousVersion(final String functionName, final String functionVersion) {
+
+        final List<String> versions = getFunctionVersions(functionName);
+
+        for(int i=0;i<versions.size()-1;i++){
+            if(versions.get(i).equals(functionVersion)){
+                getLogger().info("Version before {} is {}", functionVersion, versions.get(i+1));
+                return versions.get(i+1);
+            }
+        }
+        throw new GradleException("There is no older version than " + functionName);
+    }
+
+    /*
+    NB: Assumption here is that this returns an ordered list of versions from newest to oldest.
+    It will only be a partial list since there could be pagination. We only return first page
+     */
+    private List<String> getFunctionVersions(String functionName) {
+        final ListVersionsByFunctionRequest request = new ListVersionsByFunctionRequest().withFunctionName(functionName);
+        final AWSLambda lambda = getAwsLambdaClient();
+        final ListVersionsByFunctionResult result = lambda.listVersionsByFunction(request);
+        return result.getVersions().stream().map(FunctionConfiguration::getVersion).collect(Collectors.toList());
+    }
+
+    private AWSLambda getAwsLambdaClient() {
+        final AWSLambdaPluginExtension ext = getProject().getExtensions().getByType(AWSLambdaPluginExtension.class);
+        return ext.getClient();
+    }
+}

--- a/src/main/java/jp/classmethod/aws/gradle/lambda/AWSLambdaUpdateAliasTask.java
+++ b/src/main/java/jp/classmethod/aws/gradle/lambda/AWSLambdaUpdateAliasTask.java
@@ -63,7 +63,7 @@ public class AWSLambdaUpdateAliasTask extends ConventionTask {
     }
 
     @TaskAction
-    public void aupdateFunctionAlias(){
+    public void updateFunctionAlias(){
         // to enable conventionMappings feature
         final String functionName = getFunctionName();
         final String aliasName = getName();

--- a/src/main/java/jp/classmethod/aws/gradle/lambda/RoutingConfig.java
+++ b/src/main/java/jp/classmethod/aws/gradle/lambda/RoutingConfig.java
@@ -1,17 +1,36 @@
+/*
+ * Copyright 2015-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package jp.classmethod.aws.gradle.lambda;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import org.gradle.api.GradleException;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.Optional;
 
 import com.amazonaws.services.lambda.AWSLambda;
 import com.amazonaws.services.lambda.model.AliasRoutingConfiguration;
 import com.amazonaws.services.lambda.model.FunctionConfiguration;
 import com.amazonaws.services.lambda.model.ListVersionsByFunctionRequest;
 import com.amazonaws.services.lambda.model.ListVersionsByFunctionResult;
-import lombok.Getter;
-import lombok.Setter;
-import org.gradle.api.GradleException;
-
-import java.util.Collections;
-import java.util.List;
-import java.util.stream.Collectors;
 
 /**
  * Created by frankfarrell on 16/01/2018.
@@ -19,91 +38,104 @@ import java.util.stream.Collectors;
  * This a bit different than the aws api.
  */
 public class RoutingConfig {
-
-    @Getter
-    @Setter
-    private Double additionalVersionWeight;
-
-    @Getter
-    @Setter
-    private Boolean usePreviousVersion;
-
-    @Getter
-    @Setter
-    private Boolean useNextVersion;
-
-    @Getter
-    @Setter
-    private String additionalVersion;
-
-    public RoutingConfig() {
-    }
-
-    public AliasRoutingConfiguration getAliasRoutingConfiguration(final AWSLambda lambda,
-                                                                  final String functionName,
-                                                                  final String functionVersion){
-        if(getAdditionalVersionWeight() == null){
-            throw new GradleException("Additional Version Weight for routing config is required");
-        }
-        if(getAdditionalVersion() == null ||
-                getUsePreviousVersion() == null ||
-                getUseNextVersion() ==null){
-            throw new GradleException("Exactly one of AdditionalVersion, UsePreviousVersion, UseNextVersion for routing config is required");
-        }
-
-        final Double additionalVersionWeight = getAdditionalVersionWeight();
-
-        final AliasRoutingConfiguration aliasRoutingConfiguration = new AliasRoutingConfiguration();
-
-        if(getAdditionalVersion() != null){
-            aliasRoutingConfiguration.withAdditionalVersionWeights(Collections.singletonMap(getAdditionalVersion(), additionalVersionWeight));
-        }
-        else if(getUsePreviousVersion() != null){
-            final String prevVersion = getPreviousVersion(lambda, functionName, functionVersion);
-            aliasRoutingConfiguration.withAdditionalVersionWeights(Collections.singletonMap(prevVersion, additionalVersionWeight));
-        }
-        else{
-            final String nextVersion = getNextVersion(lambda, functionName, functionVersion);
-            aliasRoutingConfiguration.withAdditionalVersionWeights(Collections.singletonMap(nextVersion, additionalVersionWeight));
-        }
-        return aliasRoutingConfiguration;
-    }
-
-    private String getNextVersion(final AWSLambda lambda,
-                                  final String functionName,
-                                  final String functionVersion) {
-        final List<String> versions = getFunctionVersions(lambda, functionName);
-
-        for(int i=1;i<versions.size();i++){
-            if(versions.get(i).equals(functionVersion)){
-                return versions.get(i-1);
-            }
-        }
-        throw new GradleException("There is no newer version than " + functionName);
-    }
-
-    private String getPreviousVersion(final AWSLambda lambda,
-                                      final String functionName,
-                                      final String functionVersion) {
-
-        final List<String> versions = getFunctionVersions(lambda, functionName);
-
-        for(int i=0;i<versions.size()-1;i++){
-            if(versions.get(i).equals(functionVersion)){
-                return versions.get(i+1);
-            }
-        }
-        throw new GradleException("There is no older version than " + functionName);
-    }
-
-    /*
-    NB: Assumption here is that this returns an ordered list of versions from newest to oldest.
-    It will only be a partial list since there could be pagination. We only return first page
-     */
-    private List<String> getFunctionVersions(final AWSLambda lambda,
-                                             final String functionName) {
-        final ListVersionsByFunctionRequest request = new ListVersionsByFunctionRequest().withFunctionName(functionName);
-        final ListVersionsByFunctionResult result = lambda.listVersionsByFunction(request);
-        return result.getVersions().stream().map(FunctionConfiguration::getVersion).collect(Collectors.toList());
-    }
+	
+	@Input
+	@Getter
+	@Setter
+	private Double additionalVersionWeight;
+	
+	@Input
+	@Optional
+	@Getter
+	@Setter
+	private Boolean usePreviousVersion;
+	
+	@Input
+	@Optional
+	@Getter
+	@Setter
+	private Boolean useNextVersion;
+	
+	@Input
+	@Optional
+	@Getter
+	@Setter
+	private String additionalVersion;
+	
+	
+	public RoutingConfig() {
+	}
+	
+	public AliasRoutingConfiguration getAliasRoutingConfiguration(final AWSLambda lambda,
+			final String functionName,
+			final String functionVersion) {
+		if (getAdditionalVersionWeight() == null) {
+			throw new GradleException("Additional Version Weight for routing config is required");
+		}
+		if (getAdditionalVersion() == null
+				&& getUsePreviousVersion() == null
+				&& getUseNextVersion() == null) {
+			throw new GradleException("Exactly one of AdditionalVersion, UsePreviousVersion, "
+					+ "UseNextVersion for routing config is required");
+		}
+		
+		final Double additionalVersionWeight = getAdditionalVersionWeight();
+		
+		final AliasRoutingConfiguration aliasRoutingConfiguration = new AliasRoutingConfiguration();
+		
+		if (getAdditionalVersion() != null) {
+			aliasRoutingConfiguration.withAdditionalVersionWeights(
+					Collections.singletonMap(getAdditionalVersion(), additionalVersionWeight));
+		} else if (getUsePreviousVersion() != null && getUsePreviousVersion()) {
+			final String prevVersion = getPreviousVersion(lambda, functionName, functionVersion);
+			aliasRoutingConfiguration.withAdditionalVersionWeights(
+					Collections.singletonMap(prevVersion, additionalVersionWeight));
+		} else if (getUseNextVersion() != null && getUseNextVersion()){
+			final String nextVersion = getNextVersion(lambda, functionName, functionVersion);
+			aliasRoutingConfiguration.withAdditionalVersionWeights(
+					Collections.singletonMap(nextVersion, additionalVersionWeight));
+		}
+		return aliasRoutingConfiguration;
+	}
+	
+	private String getNextVersion(final AWSLambda lambda,
+			final String functionName,
+			final String functionVersion) {
+		final List<String> versions = getFunctionVersions(lambda, functionName);
+		
+		for (int i = 1; i < versions.size(); i++) {
+			if (versions.get(i).equals(functionVersion)) {
+				return versions.get(i - 1);
+			}
+		}
+		throw new GradleException("There is no newer version than "
+				+ functionName);
+	}
+	
+	private String getPreviousVersion(final AWSLambda lambda,
+			final String functionName,
+			final String functionVersion) {
+		
+		final List<String> versions = getFunctionVersions(lambda, functionName);
+		
+		for (int i = 0; i < versions.size() - 1; i++) {
+			if (versions.get(i).equals(functionVersion)) {
+				return versions.get(i + 1);
+			}
+		}
+		throw new GradleException("There is no older version than "
+				+ functionName);
+	}
+	
+	/*
+	NB: Assumption here is that this returns an ordered list of versions from newest to oldest.
+	It will only be a partial list since there could be pagination. We only return first page
+	 */
+	private List<String> getFunctionVersions(final AWSLambda lambda,
+			final String functionName) {
+		final ListVersionsByFunctionRequest request =
+				new ListVersionsByFunctionRequest().withFunctionName(functionName);
+		final ListVersionsByFunctionResult result = lambda.listVersionsByFunction(request);
+		return result.getVersions().stream().map(FunctionConfiguration::getVersion).collect(Collectors.toList());
+	}
 }

--- a/src/main/java/jp/classmethod/aws/gradle/lambda/RoutingConfig.java
+++ b/src/main/java/jp/classmethod/aws/gradle/lambda/RoutingConfig.java
@@ -1,9 +1,17 @@
 package jp.classmethod.aws.gradle.lambda;
 
+import com.amazonaws.services.lambda.AWSLambda;
+import com.amazonaws.services.lambda.model.AliasRoutingConfiguration;
+import com.amazonaws.services.lambda.model.FunctionConfiguration;
+import com.amazonaws.services.lambda.model.ListVersionsByFunctionRequest;
+import com.amazonaws.services.lambda.model.ListVersionsByFunctionResult;
 import lombok.Getter;
 import lombok.Setter;
+import org.gradle.api.GradleException;
 
-import java.util.Map;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * Created by frankfarrell on 16/01/2018.
@@ -28,7 +36,74 @@ public class RoutingConfig {
     @Setter
     private String additionalVersion;
 
-
     public RoutingConfig() {
+    }
+
+    public AliasRoutingConfiguration getAliasRoutingConfiguration(final AWSLambda lambda,
+                                                                  final String functionName,
+                                                                  final String functionVersion){
+        if(getAdditionalVersionWeight() == null){
+            throw new GradleException("Additional Version Weight for routing config is required");
+        }
+        if(getAdditionalVersion() == null ||
+                getUsePreviousVersion() == null ||
+                getUseNextVersion() ==null){
+            throw new GradleException("Exactly one of AdditionalVersion, UsePreviousVersion, UseNextVersion for routing config is required");
+        }
+
+        final Double additionalVersionWeight = getAdditionalVersionWeight();
+
+        final AliasRoutingConfiguration aliasRoutingConfiguration = new AliasRoutingConfiguration();
+
+        if(getAdditionalVersion() != null){
+            aliasRoutingConfiguration.withAdditionalVersionWeights(Collections.singletonMap(getAdditionalVersion(), additionalVersionWeight));
+        }
+        else if(getUsePreviousVersion() != null){
+            final String prevVersion = getPreviousVersion(lambda, functionName, functionVersion);
+            aliasRoutingConfiguration.withAdditionalVersionWeights(Collections.singletonMap(prevVersion, additionalVersionWeight));
+        }
+        else{
+            final String nextVersion = getNextVersion(lambda, functionName, functionVersion);
+            aliasRoutingConfiguration.withAdditionalVersionWeights(Collections.singletonMap(nextVersion, additionalVersionWeight));
+        }
+        return aliasRoutingConfiguration;
+    }
+
+    private String getNextVersion(final AWSLambda lambda,
+                                  final String functionName,
+                                  final String functionVersion) {
+        final List<String> versions = getFunctionVersions(lambda, functionName);
+
+        for(int i=1;i<versions.size();i++){
+            if(versions.get(i).equals(functionVersion)){
+                return versions.get(i-1);
+            }
+        }
+        throw new GradleException("There is no newer version than " + functionName);
+    }
+
+    private String getPreviousVersion(final AWSLambda lambda,
+                                      final String functionName,
+                                      final String functionVersion) {
+
+        final List<String> versions = getFunctionVersions(lambda, functionName);
+
+        for(int i=0;i<versions.size()-1;i++){
+            if(versions.get(i).equals(functionVersion)){
+                return versions.get(i+1);
+            }
+        }
+        throw new GradleException("There is no older version than " + functionName);
+    }
+
+    /*
+    NB: Assumption here is that this returns an ordered list of versions from newest to oldest.
+    It will only be a partial list since there could be pagination. We only return first page
+     */
+    private List<String> getFunctionVersions(final AWSLambda lambda,
+                                             final String functionName) {
+        final ListVersionsByFunctionRequest request = new ListVersionsByFunctionRequest().withFunctionName(functionName);
+        final ListVersionsByFunctionResult result = lambda.listVersionsByFunction(request);
+        return result.getVersions().stream().map(FunctionConfiguration::getVersion).collect(Collectors.toList());
     }
 }

--- a/src/main/java/jp/classmethod/aws/gradle/lambda/RoutingConfig.java
+++ b/src/main/java/jp/classmethod/aws/gradle/lambda/RoutingConfig.java
@@ -1,0 +1,34 @@
+package jp.classmethod.aws.gradle.lambda;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.Map;
+
+/**
+ * Created by frankfarrell on 16/01/2018.
+ *
+ * This a bit different than the aws api.
+ */
+public class RoutingConfig {
+
+    @Getter
+    @Setter
+    private Double additionalVersionWeight;
+
+    @Getter
+    @Setter
+    private Boolean usePreviousVersion;
+
+    @Getter
+    @Setter
+    private Boolean useNextVersion;
+
+    @Getter
+    @Setter
+    private String additionalVersion;
+
+
+    public RoutingConfig() {
+    }
+}

--- a/src/main/java/jp/classmethod/aws/gradle/lambda/RoutingConfig.java
+++ b/src/main/java/jp/classmethod/aws/gradle/lambda/RoutingConfig.java
@@ -50,6 +50,12 @@ public class RoutingConfig {
 	@Setter
 	private Boolean useNextVersion;
 	
+	/*
+	The constraint on this is the following:
+	Member must have length less than or equal to 1024, (i.e. that many digits in
+	Member must have length greater than or equal to 1,
+	Member must satisfy regular expression pattern: [0-9]+
+	 */
 	@Input
 	@Optional
 	@Getter


### PR DESCRIPTION
Closes #127 and #128 

These 3 tasks correspond to the following cli commands: 
1) https://docs.aws.amazon.com/cli/latest/reference/lambda/publish-version.html
2) https://docs.aws.amazon.com/cli/latest/reference/lambda/create-alias.html
3) https://docs.aws.amazon.com/cli/latest/reference/lambda/update-alias.html

The main use of these tasks is that you can publish new versions of lambda functions, and assign them to lambda aliases. Routing config is also configured such that you can route a percentage of traffic to another version. 2 extra variables are included useNextVersion and usePreviousVersion to avoid having to write it manually. 
http://docs.aws.amazon.com/lambda/latest/dg/lambda-traffic-shifting-using-aliases.html

Although it is already possible to publish in the MigrateFunction this could be useful to promote a function that is already migrated to a version. Eg Keep pointing $LATEST to dev alias and when you are satisfied, PublishVersion + UpdateAlias for prod. 