### PR TITLE
Depend on Lombok only for compiling

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -220,7 +220,7 @@ dependencies {
 	compile gradleApi()
 	compile "com.google.guava:guava:$guavaVersion"
 	compile "commons-io:commons-io:1.4"
-	compile "org.projectlombok:lombok:$lombokVersion"
+	compileOnly "org.projectlombok:lombok:$lombokVersion"
 
 	compile "com.amazonaws:aws-java-sdk-sts:$awsJavaSdkVersion"
 	compile "com.amazonaws:aws-java-sdk-s3:$awsJavaSdkVersion"


### PR DESCRIPTION
Lombok is only needed as an annotation processor, there's no runtime dependency on it. 

As is, using the `gradle-aws-plugin` with Gradle 4.6 generates a warning
> Deprecated Gradle features were used in this build, making it incompatible with Gradle 5.0.

which can be explicited by adding the command line option `--warning-mode=all`
> Putting annotation processors on the compile classpath has been deprecated and is scheduled to be removed in Gradle 5.0. Please add them to the processor path instead. If these processors were unintentionally leaked on the compile classpath, use the -proc:none compiler option to ignore them..

This is due to having Lombok pulled in as a dependency.