### PR TITLE
Introduce support for tagging Lambda functions within create, update,…

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,6 +313,10 @@ task migrateFunction(type: AWSLambdaMigrateFunctionTask, dependsOn: zip) {
 	    p1: "Value",
 	    p2: "Value2"
 	]
+	tags = [
+	    p1: "Value",
+	    p2: "Value2"    
+	]
 }
 
 task invokeFunction(type: AWSLambdaInvokeTask) {

--- a/src/main/java/jp/classmethod/aws/gradle/lambda/AWSLambdaCreateFunctionTask.java
+++ b/src/main/java/jp/classmethod/aws/gradle/lambda/AWSLambdaCreateFunctionTask.java
@@ -86,6 +86,10 @@ public class AWSLambdaCreateFunctionTask extends ConventionTask {
 	
 	@Getter
 	@Setter
+	private Map<String, String> tags;
+	
+	@Getter
+	@Setter
 	private Boolean publish;
 	
 	@Getter
@@ -143,6 +147,7 @@ public class AWSLambdaCreateFunctionTask extends ConventionTask {
 			.withPublish(getPublish())
 			.withVpcConfig(getVpcConfig())
 			.withEnvironment(new Environment().withVariables(getEnvironment()))
+			.withTags(getTags())
 			.withCode(functionCode);
 		createFunctionResult = lambda.createFunction(request);
 		getLogger().info("Create Lambda function requested: {}", createFunctionResult.getFunctionArn());


### PR DESCRIPTION
… and migration tasks.

I've added in the behavior to allow for tagging lambdas during creation and update steps. I used the environment variables as a reference point for how this should behave.

If tags are null, the tags remain untouched on the lambda.
If tags are present, the tags are updated on the lambda to match what is in the deployment. We diff the existing tags and the new tags. Any tags that exist on the lambda but do not exist in the deployment are removed. This is consistent with how the environment variables behave. An empty map will result in all tags being removed from the lambda.
