### PR TITLE
Fixes bug in migrate stack task, where updating an existing stack fro…

### DIFF
--- a/src/main/java/jp/classmethod/aws/gradle/cloudformation/AmazonCloudFormationMigrateStackTask.java
+++ b/src/main/java/jp/classmethod/aws/gradle/cloudformation/AmazonCloudFormationMigrateStackTask.java
@@ -172,7 +172,7 @@ public class AmazonCloudFormationMigrateStackTask extends ConventionTask {
 			req.setTemplateURL(cfnTemplateUrl);
 			getLogger().info("Using template url: {}", cfnTemplateUrl);
 			// Else, use the template file body
-		} else if (cfnStackPolicyFile != null) {
+		} else if (cfnTemplateFile != null) {
 			req.setTemplateBody(FileUtils.readFileToString(cfnTemplateFile));
 			getLogger().info("Using template file: {}", "$cfnTemplateFile.canonicalPath");
 		} else {


### PR DESCRIPTION
…m a template file fails unless a stack policy is set.

The updateStack method erroneously checks whether the stack policy file is non-null, instead of the template file.