### PR TITLE
Do not fail build if AWS is not configured

### DIFF
--- a/src/main/java/jp/classmethod/aws/gradle/AwsPluginExtension.java
+++ b/src/main/java/jp/classmethod/aws/gradle/AwsPluginExtension.java
@@ -28,6 +28,7 @@ import org.gradle.api.Project;
 
 import com.amazonaws.AmazonWebServiceClient;
 import com.amazonaws.ClientConfiguration;
+import com.amazonaws.SdkClientException;
 import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.auth.AWSCredentialsProviderChain;
 import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
@@ -146,14 +147,26 @@ public class AwsPluginExtension {
 	}
 	
 	public String getAccountId() {
-		AWSSecurityTokenService sts = createClient(AWSSecurityTokenServiceClient.class, profileName);
-		sts.setRegion(getActiveRegion(region));
-		return sts.getCallerIdentity(new GetCallerIdentityRequest()).getAccount();
+		try {
+            AWSSecurityTokenService sts = createClient(AWSSecurityTokenServiceClient.class, profileName);
+            sts.setRegion(getActiveRegion(region));
+            return sts.getCallerIdentity(new GetCallerIdentityRequest()).getAccount();
+		} catch (SdkClientException e) {
+            project.getLogger().lifecycle("AWS credentials not configured!");
+            return null;
+        }
+
 	}
 	
 	public String getUserArn() {
-		AWSSecurityTokenService sts = createClient(AWSSecurityTokenServiceClient.class, profileName);
-		sts.setRegion(getActiveRegion(region));
-		return sts.getCallerIdentity(new GetCallerIdentityRequest()).getArn();
+	    try {
+            AWSSecurityTokenService sts = createClient(AWSSecurityTokenServiceClient.class, profileName);
+            sts.setRegion(getActiveRegion(region));
+            return sts.getCallerIdentity(new GetCallerIdentityRequest()).getArn();
+        } catch (SdkClientException e) {
+            project.getLogger().lifecycle("AWS credentials not configured!");
+            return null;
+        }
+
 	}
 }

--- a/src/main/java/jp/classmethod/aws/gradle/AwsPluginExtension.java
+++ b/src/main/java/jp/classmethod/aws/gradle/AwsPluginExtension.java
@@ -148,25 +148,25 @@ public class AwsPluginExtension {
 	
 	public String getAccountId() {
 		try {
-            AWSSecurityTokenService sts = createClient(AWSSecurityTokenServiceClient.class, profileName);
-            sts.setRegion(getActiveRegion(region));
-            return sts.getCallerIdentity(new GetCallerIdentityRequest()).getAccount();
+			AWSSecurityTokenService sts = createClient(AWSSecurityTokenServiceClient.class, profileName);
+			sts.setRegion(getActiveRegion(region));
+			return sts.getCallerIdentity(new GetCallerIdentityRequest()).getAccount();
 		} catch (SdkClientException e) {
-            project.getLogger().lifecycle("AWS credentials not configured!");
-            return null;
-        }
-
+			project.getLogger().lifecycle("AWS credentials not configured!");
+			return null;
+		}
+		
 	}
 	
 	public String getUserArn() {
-	    try {
-            AWSSecurityTokenService sts = createClient(AWSSecurityTokenServiceClient.class, profileName);
-            sts.setRegion(getActiveRegion(region));
-            return sts.getCallerIdentity(new GetCallerIdentityRequest()).getArn();
-        } catch (SdkClientException e) {
-            project.getLogger().lifecycle("AWS credentials not configured!");
-            return null;
-        }
-
+		try {
+			AWSSecurityTokenService sts = createClient(AWSSecurityTokenServiceClient.class, profileName);
+			sts.setRegion(getActiveRegion(region));
+			return sts.getCallerIdentity(new GetCallerIdentityRequest()).getArn();
+		} catch (SdkClientException e) {
+			project.getLogger().lifecycle("AWS credentials not configured!");
+			return null;
+		}
+		
 	}
 }


### PR DESCRIPTION
There is a common idiom to use `aws.accountId` during the [configuration phase of the deployment task](https://github.com/micronaut-projects/micronaut-profiles/blob/master/function-aws/features/function-aws-groovy/skeleton/gradle-build/build.gradle#L10-L21):

```
    task deploy(type: jp.classmethod.aws.gradle.lambda.AWSLambdaMigrateFunctionTask, dependsOn: shadowJar) {
        functionName = "@project.name@"
        handler = "@defaultPackage@.@project.className@Function::@project.propertyName@"
        role = "arn:aws:iam::${aws.accountId}:role/lambda_basic_execution"
        runtime = com.amazonaws.services.lambda.model.Runtime.Java8
        zipFile = shadowJar.archivePath
        memorySize = 256
        timeout = 60
    }
```

For the current version, the build fails in the configuration phase if `aws.accountId` cannot be evaluated because of lack of credentials.