### PR TITLE
Add assumeRole providers support for AWS SDK

### DIFF
--- a/src/main/java/jp/classmethod/aws/gradle/AwsPluginExtension.java
+++ b/src/main/java/jp/classmethod/aws/gradle/AwsPluginExtension.java
@@ -31,9 +31,9 @@ import com.amazonaws.ClientConfiguration;
 import com.amazonaws.SdkClientException;
 import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.auth.AWSCredentialsProviderChain;
-import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
 import com.amazonaws.auth.EC2ContainerCredentialsProviderWrapper;
 import com.amazonaws.auth.EnvironmentVariableCredentialsProvider;
+import com.amazonaws.auth.STSAssumeRoleSessionCredentialsProvider;
 import com.amazonaws.auth.SystemPropertiesCredentialsProvider;
 import com.amazonaws.auth.profile.ProfileCredentialsProvider;
 import com.amazonaws.regions.Region;
@@ -58,6 +58,10 @@ public class AwsPluginExtension {
 	
 	@Getter
 	@Setter
+	private String roleArn;
+	
+	@Getter
+	@Setter
 	private String region = Regions.US_EAST_1.getName();
 	
 	@Setter
@@ -70,29 +74,37 @@ public class AwsPluginExtension {
 	private AWSCredentialsProvider credentialsProvider;
 	
 	
-	public AWSCredentialsProvider newCredentialsProvider(String profileName) {
-		if (credentialsProvider != null) {
-			return credentialsProvider;
-		}
-		String profileNameToUse = profileName != null ? profileName : this.profileName;
-		if (Strings.isNullOrEmpty(profileNameToUse) == false) {
-			List<AWSCredentialsProvider> providers = new ArrayList<AWSCredentialsProvider>();
-			providers.add(new EnvironmentVariableCredentialsProvider());
-			providers.add(new SystemPropertiesCredentialsProvider());
-			providers.add(new ProfileCredentialsProvider(profileNameToUse));
-			providers.add(new EC2ContainerCredentialsProviderWrapper());
-			return new AWSCredentialsProviderChain(providers);
-		}
-		return DefaultAWSCredentialsProviderChain.getInstance();
+	public AWSCredentialsProvider newCredentialsProvider(String profileName, String roleArn) {
+		return credentialsProvider != null ? credentialsProvider : buildCredentialsProvider(profileName, roleArn);
 	}
 	
-	public <T extends AmazonWebServiceClient> T createClient(Class<T> serviceClass, String profileName) {
-		return createClient(serviceClass, profileName, null);
+	private AWSCredentialsProvider buildCredentialsProvider(String profileName, String roleArn) {
+		List<AWSCredentialsProvider> providers = new ArrayList<>();
+		providers.add(new EnvironmentVariableCredentialsProvider());
+		providers.add(new SystemPropertiesCredentialsProvider());
+		
+		String profileNameToUse = profileName != null ? profileName : this.profileName;
+		if (!Strings.isNullOrEmpty(profileNameToUse)) {
+			providers.add(new ProfileCredentialsProvider(profileNameToUse));
+		}
+		String roleArnToUse = roleArn != null ? roleArn : this.roleArn;
+		if (!Strings.isNullOrEmpty(roleArnToUse)) {
+			STSAssumeRoleSessionCredentialsProvider assumeRoleProvider =
+					new STSAssumeRoleSessionCredentialsProvider.Builder(roleArnToUse, "gradle").build();
+			providers.add(assumeRoleProvider);
+		}
+		providers.add(new EC2ContainerCredentialsProviderWrapper());
+		return new AWSCredentialsProviderChain(providers);
 	}
 	
 	public <T extends AmazonWebServiceClient> T createClient(Class<T> serviceClass, String profileName,
+			String roleArn) {
+		return createClient(serviceClass, profileName, roleArn, null);
+	}
+	
+	public <T extends AmazonWebServiceClient> T createClient(Class<T> serviceClass, String profileName, String roleArn,
 			ClientConfiguration config) {
-		AWSCredentialsProvider credentialsProvider = newCredentialsProvider(profileName);
+		AWSCredentialsProvider credentialsProvider = newCredentialsProvider(profileName, roleArn);
 		ClientConfiguration configToUse = config == null ? new ClientConfiguration() : config;
 		if (this.proxyHost != null && this.proxyPort > 0) {
 			configToUse.setProxyHost(this.proxyHost);
@@ -148,7 +160,7 @@ public class AwsPluginExtension {
 	
 	public String getAccountId() {
 		try {
-			AWSSecurityTokenService sts = createClient(AWSSecurityTokenServiceClient.class, profileName);
+			AWSSecurityTokenService sts = createClient(AWSSecurityTokenServiceClient.class, profileName, roleArn);
 			sts.setRegion(getActiveRegion(region));
 			return sts.getCallerIdentity(new GetCallerIdentityRequest()).getAccount();
 		} catch (SdkClientException e) {
@@ -160,7 +172,7 @@ public class AwsPluginExtension {
 	
 	public String getUserArn() {
 		try {
-			AWSSecurityTokenService sts = createClient(AWSSecurityTokenServiceClient.class, profileName);
+			AWSSecurityTokenService sts = createClient(AWSSecurityTokenServiceClient.class, profileName, roleArn);
 			sts.setRegion(getActiveRegion(region));
 			return sts.getCallerIdentity(new GetCallerIdentityRequest()).getArn();
 		} catch (SdkClientException e) {

--- a/src/main/java/jp/classmethod/aws/gradle/cloudformation/AmazonCloudFormationMigrateStackTask.java
+++ b/src/main/java/jp/classmethod/aws/gradle/cloudformation/AmazonCloudFormationMigrateStackTask.java
@@ -172,7 +172,7 @@ public class AmazonCloudFormationMigrateStackTask extends ConventionTask {
 			req.setTemplateURL(cfnTemplateUrl);
 			getLogger().info("Using template url: {}", cfnTemplateUrl);
 			// Else, use the template file body
-		} else if (cfnStackPolicyFile != null) {
+		} else if (cfnTemplateFile != null) {
 			req.setTemplateBody(FileUtils.readFileToString(cfnTemplateFile));
 			getLogger().info("Using template file: {}", "$cfnTemplateFile.canonicalPath");
 		} else {

--- a/src/main/java/jp/classmethod/aws/gradle/common/BasePluginExtension.java
+++ b/src/main/java/jp/classmethod/aws/gradle/common/BasePluginExtension.java
@@ -38,6 +38,10 @@ public abstract class BasePluginExtension<T extends AmazonWebServiceClient> {
 	@Setter
 	private String profileName;
 	
+	@Getter
+	@Setter
+	private String roleArn;
+	
 	@Getter(lazy = true, onMethod = @__(@SuppressWarnings("unchecked")))
 	private final T client = initClient();
 	
@@ -49,7 +53,7 @@ public abstract class BasePluginExtension<T extends AmazonWebServiceClient> {
 	
 	protected T initClient() {
 		AwsPluginExtension aws = project.getExtensions().getByType(AwsPluginExtension.class);
-		return aws.createClient(awsClientClass, profileName, buildClientConfiguration());
+		return aws.createClient(awsClientClass, profileName, roleArn, buildClientConfiguration());
 	}
 	
 	/**


### PR DESCRIPTION
Currently it is not possible to use [AssumeRole](https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/auth/STSAssumeRoleSessionCredentialsProvider.html).
This code aims to fix that by allowing user to pass a `roleArn` that they want to use to perform AWS requests.

Also, it fixes a little issue with templateFile in `AmazonCloudFormationMigrateStackTask` that forced user to specify a policy file (even an empty one) to update their stack.