### PR TITLE
Create change set role arn

### DIFF
--- a/src/main/java/jp/classmethod/aws/gradle/cloudformation/AmazonCloudFormationCreateChangeSetTask.java
+++ b/src/main/java/jp/classmethod/aws/gradle/cloudformation/AmazonCloudFormationCreateChangeSetTask.java
@@ -66,7 +66,11 @@ public class AmazonCloudFormationCreateChangeSetTask extends ConventionTask {
 	@Getter
 	@Setter
 	private List<Tag> cfnStackTags = new ArrayList<>();
-	
+
+	@Getter
+	@Setter
+	private String cfnRoleArn;
+
 	@Getter
 	@Setter
 	private boolean capabilityIam;
@@ -74,10 +78,6 @@ public class AmazonCloudFormationCreateChangeSetTask extends ConventionTask {
 	@Getter
 	@Setter
 	private Capability useCapabilityIam;
-
-	@Getter
-	@Setter
-	private String cfnRoleArn;
 
 	@Getter
 	@Setter
@@ -140,8 +140,8 @@ public class AmazonCloudFormationCreateChangeSetTask extends ConventionTask {
 			.withStackName(stackName)
 			.withParameters(cfnStackParams)
 			.withTags(cfnStackTags)
-			.withChangeSetType(changeSetType)
-			.withRoleARN(cfnRoleArn);
+			.withRoleARN(cfnRoleArn)
+			.withChangeSetType(changeSetType);
 
 		// If template URL is specified, then use it
 		if (Strings.isNullOrEmpty(cfnTemplateUrl) == false) {

--- a/src/main/java/jp/classmethod/aws/gradle/cloudformation/AmazonCloudFormationCreateChangeSetTask.java
+++ b/src/main/java/jp/classmethod/aws/gradle/cloudformation/AmazonCloudFormationCreateChangeSetTask.java
@@ -74,7 +74,11 @@ public class AmazonCloudFormationCreateChangeSetTask extends ConventionTask {
 	@Getter
 	@Setter
 	private Capability useCapabilityIam;
-	
+
+	@Getter
+	@Setter
+	private String cfnRoleArn;
+
 	@Getter
 	@Setter
 	private List<String> stableStatuses = Arrays.asList(
@@ -127,6 +131,7 @@ public class AmazonCloudFormationCreateChangeSetTask extends ConventionTask {
 		List<Parameter> cfnStackParams = getCfnStackParams();
 		List<Tag> cfnStackTags = getCfnStackTags();
 		File cfnTemplateFile = getCfnTemplateFile();
+		String cfnRoleArn = getCfnRoleArn();
 		
 		String changeSetName = changeSetName(stackName);
 		getLogger().info("Create change set '{}' for stack '{}'", changeSetName, stackName);
@@ -135,8 +140,9 @@ public class AmazonCloudFormationCreateChangeSetTask extends ConventionTask {
 			.withStackName(stackName)
 			.withParameters(cfnStackParams)
 			.withTags(cfnStackTags)
-			.withChangeSetType(changeSetType);
-		
+			.withChangeSetType(changeSetType)
+			.withRoleARN(cfnRoleArn);
+
 		// If template URL is specified, then use it
 		if (Strings.isNullOrEmpty(cfnTemplateUrl) == false) {
 			req.setTemplateURL(cfnTemplateUrl);

--- a/src/main/java/jp/classmethod/aws/gradle/cloudformation/AmazonCloudFormationCreateChangeSetTask.java
+++ b/src/main/java/jp/classmethod/aws/gradle/cloudformation/AmazonCloudFormationCreateChangeSetTask.java
@@ -66,11 +66,11 @@ public class AmazonCloudFormationCreateChangeSetTask extends ConventionTask {
 	@Getter
 	@Setter
 	private List<Tag> cfnStackTags = new ArrayList<>();
-
+	
 	@Getter
 	@Setter
 	private String cfnRoleArn;
-
+	
 	@Getter
 	@Setter
 	private boolean capabilityIam;
@@ -78,7 +78,7 @@ public class AmazonCloudFormationCreateChangeSetTask extends ConventionTask {
 	@Getter
 	@Setter
 	private Capability useCapabilityIam;
-
+	
 	@Getter
 	@Setter
 	private List<String> stableStatuses = Arrays.asList(
@@ -132,7 +132,7 @@ public class AmazonCloudFormationCreateChangeSetTask extends ConventionTask {
 		List<Tag> cfnStackTags = getCfnStackTags();
 		String cfnRoleArn = getCfnRoleArn();
 		File cfnTemplateFile = getCfnTemplateFile();
-
+		
 		String changeSetName = changeSetName(stackName);
 		getLogger().info("Create change set '{}' for stack '{}'", changeSetName, stackName);
 		CreateChangeSetRequest req = new CreateChangeSetRequest()
@@ -142,7 +142,7 @@ public class AmazonCloudFormationCreateChangeSetTask extends ConventionTask {
 			.withTags(cfnStackTags)
 			.withRoleARN(cfnRoleArn)
 			.withChangeSetType(changeSetType);
-
+		
 		// If template URL is specified, then use it
 		if (Strings.isNullOrEmpty(cfnTemplateUrl) == false) {
 			req.setTemplateURL(cfnTemplateUrl);

--- a/src/main/java/jp/classmethod/aws/gradle/cloudformation/AmazonCloudFormationCreateChangeSetTask.java
+++ b/src/main/java/jp/classmethod/aws/gradle/cloudformation/AmazonCloudFormationCreateChangeSetTask.java
@@ -130,9 +130,9 @@ public class AmazonCloudFormationCreateChangeSetTask extends ConventionTask {
 		String cfnTemplateUrl = getCfnTemplateUrl();
 		List<Parameter> cfnStackParams = getCfnStackParams();
 		List<Tag> cfnStackTags = getCfnStackTags();
-		File cfnTemplateFile = getCfnTemplateFile();
 		String cfnRoleArn = getCfnRoleArn();
-		
+		File cfnTemplateFile = getCfnTemplateFile();
+
 		String changeSetName = changeSetName(stackName);
 		getLogger().info("Create change set '{}' for stack '{}'", changeSetName, stackName);
 		CreateChangeSetRequest req = new CreateChangeSetRequest()

--- a/src/main/java/jp/classmethod/aws/gradle/cloudformation/AmazonCloudFormationPlugin.java
+++ b/src/main/java/jp/classmethod/aws/gradle/cloudformation/AmazonCloudFormationPlugin.java
@@ -130,6 +130,7 @@ public class AmazonCloudFormationPlugin implements Plugin<Project> {
 					.collect(Collectors.toList()));
 				task.conventionMapping("cfnTemplateUrl", () -> cfnExt.getTemplateURL());
 				task.conventionMapping("cfnTemplateFile", () -> cfnExt.getTemplateFile());
+				task.conventionMapping("cfnRoleArn", () -> cfnExt.getRoleArn());
 			});
 		
 		AmazonCloudFormationWaitStackStatusTask awsCfnWaitStackCompleteAfterCreateChangeSet = project.getTasks().create(

--- a/src/main/java/jp/classmethod/aws/gradle/cloudformation/AmazonCloudFormationPlugin.java
+++ b/src/main/java/jp/classmethod/aws/gradle/cloudformation/AmazonCloudFormationPlugin.java
@@ -128,9 +128,9 @@ public class AmazonCloudFormationPlugin implements Plugin<Project> {
 						.withKey(it.getKey().toString())
 						.withValue(it.getValue().toString()))
 					.collect(Collectors.toList()));
+				task.conventionMapping("cfnRoleArn", () -> cfnExt.getCfnRoleArn());
 				task.conventionMapping("cfnTemplateUrl", () -> cfnExt.getTemplateURL());
 				task.conventionMapping("cfnTemplateFile", () -> cfnExt.getTemplateFile());
-				task.conventionMapping("cfnRoleArn", () -> cfnExt.getRoleArn());
 			});
 		
 		AmazonCloudFormationWaitStackStatusTask awsCfnWaitStackCompleteAfterCreateChangeSet = project.getTasks().create(

--- a/src/main/java/jp/classmethod/aws/gradle/cloudformation/AmazonCloudFormationPluginExtension.java
+++ b/src/main/java/jp/classmethod/aws/gradle/cloudformation/AmazonCloudFormationPluginExtension.java
@@ -65,7 +65,11 @@ public class AmazonCloudFormationPluginExtension extends BaseRegionAwarePluginEx
 	@Getter
 	@Setter
 	private Map<?, ?> stackTags = new HashMap<>();
-	
+
+	@Getter
+	@Setter
+	private String cfnRoleArn;
+
 	@Getter
 	@Setter
 	private String templateURL;

--- a/src/main/java/jp/classmethod/aws/gradle/cloudformation/AmazonCloudFormationPluginExtension.java
+++ b/src/main/java/jp/classmethod/aws/gradle/cloudformation/AmazonCloudFormationPluginExtension.java
@@ -65,11 +65,11 @@ public class AmazonCloudFormationPluginExtension extends BaseRegionAwarePluginEx
 	@Getter
 	@Setter
 	private Map<?, ?> stackTags = new HashMap<>();
-
+	
 	@Getter
 	@Setter
 	private String cfnRoleArn;
-
+	
 	@Getter
 	@Setter
 	private String templateURL;


### PR DESCRIPTION
When creating a CloudFormation change set via the AWS API you can pass the `--role-arn` parameter, which is a role to be assumed when executing the change set (see [docs here](https://docs.aws.amazon.com/cli/latest/reference/cloudformation/create-change-set.html))

This change adds a new plugin parameter `cfnRoleArn` to the cloudFormation configuration.

Note, this is not to be confused with the `roleArn` parameter, which has a separate use case.

e.g.

```
cloudFormation {
    cfnRoleArn = 'arn:aws:iam::123456789:role/cloudformation-init-CloudFormationServiceRole-ABCDEF1234'
}
```

