### PR TITLE
Set roleArn on the awsCfnMigrateStack task.

### DIFF
--- a/src/main/java/jp/classmethod/aws/gradle/cloudformation/AmazonCloudFormationMigrateStackTask.java
+++ b/src/main/java/jp/classmethod/aws/gradle/cloudformation/AmazonCloudFormationMigrateStackTask.java
@@ -65,7 +65,7 @@ public class AmazonCloudFormationMigrateStackTask extends ConventionTask {
 	@Getter
 	@Setter
 	private List<Tag> cfnStackTags = new ArrayList<>();
-
+	
 	@Getter
 	@Setter
 	private String cfnRoleArn;
@@ -171,7 +171,7 @@ public class AmazonCloudFormationMigrateStackTask extends ConventionTask {
 			.withStackName(stackName)
 			.withParameters(cfnStackParams)
 			.withTags(cfnStackTags)
-			.withRoleARN( cfnRoleArn );
+			.withRoleARN(cfnRoleArn);
 		
 		// If template URL is specified, then use it
 		if (Strings.isNullOrEmpty(cfnTemplateUrl) == false) {

--- a/src/main/java/jp/classmethod/aws/gradle/cloudformation/AmazonCloudFormationMigrateStackTask.java
+++ b/src/main/java/jp/classmethod/aws/gradle/cloudformation/AmazonCloudFormationMigrateStackTask.java
@@ -65,6 +65,10 @@ public class AmazonCloudFormationMigrateStackTask extends ConventionTask {
 	@Getter
 	@Setter
 	private List<Tag> cfnStackTags = new ArrayList<>();
+
+	@Getter
+	@Setter
+	private String cfnRoleArn;
 	
 	@Getter
 	@Setter
@@ -149,6 +153,7 @@ public class AmazonCloudFormationMigrateStackTask extends ConventionTask {
 		File cfnTemplateFile = getCfnTemplateFile();
 		List<Parameter> cfnStackParams = getCfnStackParams();
 		List<Tag> cfnStackTags = getCfnStackTags();
+		String cfnRoleArn = getCfnRoleArn();
 		String cfnStackPolicyUrl = getCfnStackPolicyUrl();
 		File cfnStackPolicyFile = getCfnStackPolicyFile();
 		
@@ -165,7 +170,8 @@ public class AmazonCloudFormationMigrateStackTask extends ConventionTask {
 		UpdateStackRequest req = new UpdateStackRequest()
 			.withStackName(stackName)
 			.withParameters(cfnStackParams)
-			.withTags(cfnStackTags);
+			.withTags(cfnStackTags)
+			.withRoleARN( cfnRoleArn );
 		
 		// If template URL is specified, then use it
 		if (Strings.isNullOrEmpty(cfnTemplateUrl) == false) {

--- a/src/main/java/jp/classmethod/aws/gradle/cloudformation/AmazonCloudFormationPlugin.java
+++ b/src/main/java/jp/classmethod/aws/gradle/cloudformation/AmazonCloudFormationPlugin.java
@@ -96,6 +96,7 @@ public class AmazonCloudFormationPlugin implements Plugin<Project> {
 						.withKey(it.getKey().toString())
 						.withValue(it.getValue().toString()))
 					.collect(Collectors.toList()));
+				task.conventionMapping("cfnRoleArn", () -> cfnExt.getCfnRoleArn());
 				task.conventionMapping("cfnTemplateUrl", () -> cfnExt.getTemplateURL());
 				task.conventionMapping("cfnTemplateFile", () -> cfnExt.getTemplateFile());
 				task.conventionMapping("cfnStackPolicyUrl", () -> cfnExt.getStackPolicyURL());


### PR DESCRIPTION
The `AmazonCloudFormationMigrateStackTask` class uses the AWS Java SDK class `UpdateStackRequest` which allows `roleARN` to be passed in. 

> The Amazon Resource Name (ARN) of an AWS Identity and Access Management (IAM) role that AWS CloudFormation assumes to update the stack.

This change exposes this so that the value is pulled in from the `cfnRoleArn ` configuration variable. e.g.

```
cloudFormation {
    stackName 'test-stack'
    templateFile project.file('stack.yml')
    cfnRoleArn 'my-special-role'
}
```