### PR TITLE
Add ability to create lambda resource policies

### DIFF
--- a/src/main/java/jp/classmethod/aws/gradle/lambda/AWSLambdaCreateFunctionTask.java
+++ b/src/main/java/jp/classmethod/aws/gradle/lambda/AWSLambdaCreateFunctionTask.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.io.RandomAccessFile;
 import java.nio.MappedByteBuffer;
 import java.nio.channels.FileChannel;
+import java.util.Collection;
 import java.util.Map;
 
 import lombok.Getter;
@@ -28,6 +29,8 @@ import lombok.Setter;
 
 import org.gradle.api.GradleException;
 import org.gradle.api.internal.ConventionTask;
+import org.gradle.api.logging.Logger;
+import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.TaskAction;
 
 import com.amazonaws.services.lambda.AWSLambda;
@@ -79,6 +82,11 @@ public class AWSLambdaCreateFunctionTask extends ConventionTask {
 	@Getter
 	@Setter
 	private VpcConfigWrapper vpc;
+	
+	@Getter
+	@Setter
+	@Optional
+	private Collection<ResourcePermission> resourcePermissions;
 	
 	@Getter
 	@Setter
@@ -150,7 +158,14 @@ public class AWSLambdaCreateFunctionTask extends ConventionTask {
 			.withTags(getTags())
 			.withCode(functionCode);
 		createFunctionResult = lambda.createFunction(request);
-		getLogger().info("Create Lambda function requested: {}", createFunctionResult.getFunctionArn());
+		final Logger logger = getLogger();
+		logger.info("Create Lambda function requested: {}", createFunctionResult.getFunctionArn());
+		
+		final Collection<ResourcePermission> resourcePermissions = getResourcePermissions();
+		if (resourcePermissions != null) {
+			ResourcePermission.createOrUpdateResourcePermissions(lambda, logger, getFunctionName(),
+					resourcePermissions);
+		}
 	}
 	
 	private VpcConfig getVpcConfig() {

--- a/src/main/java/jp/classmethod/aws/gradle/lambda/ResourcePermission.java
+++ b/src/main/java/jp/classmethod/aws/gradle/lambda/ResourcePermission.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2015-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package jp.classmethod.aws.gradle.lambda;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import org.gradle.api.logging.Logger;
+
+import com.amazonaws.services.lambda.AWSLambda;
+import com.amazonaws.services.lambda.model.AddPermissionRequest;
+import com.amazonaws.services.lambda.model.AddPermissionResult;
+import com.amazonaws.services.lambda.model.RemovePermissionRequest;
+import com.amazonaws.services.lambda.model.ResourceNotFoundException;
+
+public class ResourcePermission {
+	
+	@Getter
+	@Setter
+	private String action;
+	
+	@Getter
+	@Setter
+	private String principal;
+	
+	@Getter
+	@Setter
+	private String sourceArn;
+	
+	@Getter
+	@Setter
+	private String statementId;
+	
+	
+	protected ResourcePermission() {
+		/*
+		An empty constructor is needed so that gradle can resolve variable to an instance,
+		eg to make this work as a nested task property
+		 */
+	}
+	
+	static ResourcePermission of(String statementId, String action, String principal, String sourceArn) {
+		final ResourcePermission resourcePermission = new ResourcePermission();
+		resourcePermission.setStatementId(statementId);
+		resourcePermission.setAction(action);
+		resourcePermission.setPrincipal(principal);
+		resourcePermission.setSourceArn(sourceArn);
+		return resourcePermission;
+	}
+	
+	static void createOrUpdateResourcePermissions(final AWSLambda lambda, final Logger logger,
+			final String functionName, final Collection<ResourcePermission> resourcePermissions) {
+		final List<AddPermissionResult> functionResourcePolicyResults =
+				resourcePermissions.stream().map(rp -> rp.addOrUpdatePermissionToPolicy(lambda, functionName))
+					.collect(Collectors.toList());
+		functionResourcePolicyResults
+			.forEach(result -> logger.info("Create Lambda function resource policy statement requested: {}", result));
+	}
+	
+	public AddPermissionResult addOrUpdatePermissionToPolicy(final AWSLambda lambda, final String functionName) {
+		final RemovePermissionRequest removePermissionRequest = new RemovePermissionRequest();
+		removePermissionRequest.setStatementId(statementId);
+		removePermissionRequest.setFunctionName(functionName);
+		try {
+			lambda.removePermission(removePermissionRequest);
+		} catch (ResourceNotFoundException e) {
+			// nothing to do here, we will create the resource next
+		}
+		
+		final AddPermissionRequest addPermissionRequest = new AddPermissionRequest();
+		addPermissionRequest.setStatementId(statementId);
+		addPermissionRequest.setFunctionName(functionName);
+		addPermissionRequest.setAction(this.getAction());
+		addPermissionRequest.setPrincipal(this.getPrincipal());
+		addPermissionRequest.setSourceArn(this.getSourceArn());
+		return lambda.addPermission(addPermissionRequest);
+	}
+}


### PR DESCRIPTION
Thanks for this very useful plugin. While using it I missed the ability to set resource policies on lambda functions in order to allow other services (in my case Amazon Lex) to invoke the lambdas I deploy via the plugin.

This is my first attempt at contributing to a gradle plugin and, I've made this PR with my own use case in mind and no other. Therefore, I will be very happy to receive feedback to improve this PR since I expect that there will be lots of things that can be done better. 

I'm currently using the feature introduced in this PR as follows
```
import jp.classmethod.aws.gradle.lambda.ResourcePermission;

task deploy(type: jp.classmethod.aws.gradle.lambda.AWSLambdaMigrateFunctionTask, dependsOn: shadowJar) {
    functionName = "myFunction"
    handler = "com.example.Function::apply"
    role = "arn:aws:iam::${aws.accountId}:role/service-role/some-role"
    runtime = com.amazonaws.services.lambda.model.Runtime.Java8
    zipFile = shadowJar.archivePath
    memorySize = 256
    timeout = 60

    resourcePermissions = [ResourcePermission.of("testStatement", "lambda:invokeFunction", "lex.amazonaws.com", "arn:aws:lex:eu-west-1:123458678910:intent:*")]
}
```

I wanted to configure the `resourcePermissions` property using a groovy map (expecting it to be serialised to the right class) but that did not work.